### PR TITLE
Tlsa/codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,28 @@
 language: c
 sudo: required
+matrix:
+  include:
+    - compiler: gcc
+    - compiler: clang
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcovr
+      env:
+        - BUILD_TYPE=Coverage
 before_install:
-    - sudo apt-get update -qq
-    - sudo apt-get install -y valgrind libyaml-dev
-compiler:
-    - clang
-    - gcc
+  - sudo apt-get update -qq
+  - sudo apt-get install -y valgrind libyaml-dev
 script:
-    - make test
-    - make valgrind-quiet
+  - make test
+  - make valgrind-quiet
+  - |
+    if [[ "${BUILD_TYPE}" == "Coverage" ]]; then
+      make coverage;
+      rm build/coverage.xml
+      bash <(curl -s https://codecov.io/bash) -g "*test*";
+    fi
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 LibCYAML: Schema-based YAML parsing and serialisation
 =====================================================
 
-[![Build Status](https://travis-ci.org/tlsa/libcyaml.svg?branch=master)](https://travis-ci.org/tlsa/libcyaml)
+[![Build Status](https://travis-ci.org/tlsa/libcyaml.svg?branch=master)](https://travis-ci.org/tlsa/libcyaml) [![Code Coverage](https://codecov.io/gh/tlsa/libcyaml/branch/master/graph/badge.svg)](https://codecov.io/gh/tlsa/libcyaml)
 
 LibCYAML is a C library for reading and writing structured YAML documents.
 It is written in ISO C11 and licensed under the ISC licence.


### PR DESCRIPTION
Add a coverage build to the CI, using https://codecov.io/ for the result presentation.