### PR TITLE
Tlsa/library versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,14 @@ else
 $(error VARIANT must be 'debug' (default) or 'release')
 endif
 
+# CYAML's versioning is <MAJOR>.<MINOR>.<PATCH>[-DEVEL]
+# Master branch will always be DEVEL.  The release process will be to make
+# the release branch, set VESION_DEVEL to 0, and tag the release.
+VERSION_MAJOR = 0
+VERSION_MINOR = 0
+VERSION_PATCH = 0
+VERSION_DEVEL = 1 # Zero or one only.
+
 .IMPLICIT =
 
 CC = gcc
@@ -18,8 +26,13 @@ LD = $(CC)
 MKDIR =	mkdir -p
 VALGRIND = valgrind --leak-check=full --track-origins=yes
 
+VERSION_FLAGS = -DVERSION_MAJOR=$(VERSION_MAJOR) \
+                -DVERSION_MINOR=$(VERSION_MINOR) \
+                -DVERSION_PATCH=$(VERSION_PATCH) \
+                -DVERSION_DEVEL=$(VERSION_DEVEL)
+
 INCLUDE = -I include -I src
-CCFLAGS += $(INCLUDE)
+CCFLAGS += $(INCLUDE) $(VERSION_FLAGS)
 CCFLAGS += -std=c11 -Wall -Wextra -pedantic
 LDFLAGS = -lyaml
 ARFLAGS = -shared

--- a/include/cyaml.h
+++ b/include/cyaml.h
@@ -17,6 +17,26 @@
 #define CYAML_H
 
 /**
+ * CYAML library version string.
+ */
+extern const char *cyaml_version_str;
+
+/**
+ * CYAML library version number suitable for comparisons.
+ *
+ * Version number binary composition is `0bRUUUUUUUJJJJJJJJNNNNNNNNPPPPPPPP`.
+ *
+ * | Character | Meaning                                |
+ * | --------- | -------------------------------------- |
+ * | `R`       | Release flag.  If set, it's a release. |
+ * | `U`       | Unused / reserved.                     |
+ * | `J`       | Major component of version.            |
+ * | `N`       | Minor component of version.            |
+ * | `P`       | Patch component of version.            |
+ */
+extern const uint32_t cyaml_version;
+
+/**
  * CYAML value types.
  */
 typedef enum cyaml_type {

--- a/src/util.c
+++ b/src/util.c
@@ -17,6 +17,46 @@
 
 #include "util.h"
 
+/** Flag that indicates a release in \ref cyaml_version. */
+#define CYAML_RELEASE_FLAG (1u << 31)
+
+/** Stringification helper macro. */
+#define CYAML_STR_HELPER(_x) #_x
+
+/** Stringification macro. */
+#define CYAML_STR(_x) CYAML_STR_HELPER(_x)
+
+/* Version depends on whether we're a development build. */
+#if VERSION_DEVEL
+	/** Version string is composed from components in Makefile. */
+	#define CYAML_VERSION_STR \
+			CYAML_STR(VERSION_MAJOR) "." \
+			CYAML_STR(VERSION_MINOR) "." \
+			CYAML_STR(VERSION_PATCH) "-DEVEL"
+
+	/* Exported constant, documented in include/cyaml/cyaml.h */
+	const uint32_t cyaml_version =
+			((VERSION_MAJOR << 16) |
+			 (VERSION_MINOR <<  8) |
+			 (VERSION_PATCH <<  0));
+#else
+	/** Version string is composed from components in Makefile. */
+	#define CYAML_VERSION_STR \
+			CYAML_STR(VERSION_MAJOR) "." \
+			CYAML_STR(VERSION_MINOR) "." \
+			CYAML_STR(VERSION_PATCH)
+
+	/* Exported constant, documented in include/cyaml/cyaml.h */
+	const uint32_t cyaml_version =
+			((VERSION_MAJOR << 16) |
+			 (VERSION_MINOR <<  8) |
+			 (VERSION_PATCH <<  0) |
+			 CYAML_RELEASE_FLAG);
+#endif
+
+/* Exported constant, documented in include/cyaml/cyaml.h */
+const char *cyaml_version_str = CYAML_VERSION_STR;
+
 /* Exported function, documented in include/cyaml/cyaml.h */
 void cyaml_log(
 		cyaml_log_t level,


### PR DESCRIPTION
The version number is controlled from the build system.

The version number is exposed to clients as string and numerically.