### PR TITLE
Allow non-continuous enum/flag values.

### DIFF
--- a/include/cyaml.h
+++ b/include/cyaml.h
@@ -42,15 +42,16 @@ typedef enum cyaml_type {
 	CYAML_UINT,     /**< Value is an unsigned signed integer. */
 	CYAML_BOOL,     /**< Value is a boolean. */
 	/**
-	 * Value is an enum.  Values of this type require a string list in
-	 * the schema entry, to define the list of valid enum values.
+	 * Value is an enum.  Values of this type require a string / value
+	 * mapping array in the schema entry, to define the list of valid
+	 * enum values.
 	 */
 	CYAML_ENUM,
 	/**
-	 * Value is a flags bit field.  Values of this type require a string
-	 * list in the schema entry, to define the list of valid flag values.
-	 * In the YAML, a \ref CYAML_FLAGS value must be presented as a
-	 * sequence of strings.
+	 * Value is a flags bit field.  Values of this type require a string /
+	 * value list in the schema entry, to define the list of valid flag
+	 * values.  In the YAML, a \ref CYAML_FLAGS value must be presented as
+	 * a sequence of strings.
 	 */
 	CYAML_FLAGS,
 	CYAML_FLOAT,    /**< Value is floating point. */
@@ -156,6 +157,16 @@ typedef enum cyaml_flag {
 } cyaml_flag_e;
 
 /**
+ * Mapping between a string and a signed value.
+ *
+ * Used for \ref CYAML_ENUM and \ref CYAML_FLAGS types.
+ */
+typedef struct cyaml_strval {
+	const char *str; /**< String representing enum or flag value. */
+	int64_t val;     /**< Value of given string. */
+} cyaml_strval_t;
+
+/**
  * Schema definition for a value.
  *
  * There are convenience macros for each of the types to assist in
@@ -242,8 +253,8 @@ typedef struct cyaml_schema_value {
 		 * data.
 		 */
 		struct {
-			/** Array of strings defining enum or flags values. */
-			const char * const *strings;
+			/** Array of string / value mappings defining enum. */
+			const cyaml_strval_t *strings;
 			/** Entry count for strings array. */
 			uint32_t count;
 		} enumeration;

--- a/src/load.c
+++ b/src/load.c
@@ -735,8 +735,10 @@ static cyaml_err_t cyaml__read_enum(
 		uint8_t *data)
 {
 	for (uint32_t i = 0; i < schema->enumeration.count; i++) {
-		if (strcmp(value, schema->enumeration.strings[i]) == 0) {
-			return cyaml_data_write(i, schema->data_size, data);
+		if (strcmp(value, schema->enumeration.strings[i].str) == 0) {
+			return cyaml_data_write(
+					schema->enumeration.strings[i].val,
+					schema->data_size, data);
 		}
 	}
 
@@ -956,8 +958,8 @@ static cyaml_err_t cyaml__set_flag(
 		uint64_t *flags_out)
 {
 	for (uint32_t i = 0; i < schema->enumeration.count; i++) {
-		if (strcmp(value, schema->enumeration.strings[i]) == 0) {
-			*flags_out |= (1 << i);
+		if (strcmp(value, schema->enumeration.strings[i].str) == 0) {
+			*flags_out |= schema->enumeration.strings[i].val;
 			return CYAML_OK;
 		}
 	}

--- a/src/save.c
+++ b/src/save.c
@@ -692,10 +692,13 @@ static cyaml_err_t cyaml__write_enum(
 
 	number = cyaml_data_read(schema->data_size, data, &err);
 	if (err == CYAML_OK) {
-		const char * const *strings = schema->enumeration.strings;
+		const cyaml_strval_t *strings = schema->enumeration.strings;
 		const char *string = NULL;
-		if (number < schema->enumeration.count) {
-			string = strings[number];
+		for (uint32_t i = 0; i < schema->enumeration.count; i++) {
+			if (number == strings[i].val) {
+				string = strings[i].str;
+				break;
+			}
 		}
 		if (string == NULL) {
 			if (schema->flags & CYAML_FLAG_STRICT) {
@@ -808,7 +811,7 @@ static cyaml_err_t cyaml__emit_flags_sequence(
 		const cyaml_schema_value_t *schema,
 		uint64_t number)
 {
-	const char * const *strings = schema->enumeration.strings;
+	const cyaml_strval_t *strings = schema->enumeration.strings;
 	yaml_event_t event;
 	cyaml_err_t err;
 	int ret;
@@ -824,9 +827,9 @@ static cyaml_err_t cyaml__emit_flags_sequence(
 
 	for (uint32_t i = 0; i < schema->enumeration.count; i++) {
 		cyaml_err_t err;
-		uint64_t flag = ((int64_t)1) << i;
+		uint64_t flag = strings->val;
 		if (number & flag) {
-			err = cyaml__emit_scalar(ctx, schema, *strings,
+			err = cyaml__emit_scalar(ctx, schema, strings->str,
 					YAML_STR_TAG);
 			if (err != CYAML_OK) {
 				return err;

--- a/test/units/errs.c
+++ b/test/units/errs.c
@@ -871,11 +871,11 @@ static bool test_err_load_schema_bad_data_size_3(
 		ttest_report_ctx_t *report,
 		const cyaml_config_t *config)
 {
-	static const char * const strings[] = {
-		"foo",
-		"bar",
-		"baz",
-		"bat",
+	static const cyaml_strval_t strings[] = {
+		{ "foo", 0 },
+		{ "bar", 1 },
+		{ "baz", 2 },
+		{ "bat", 3 },
 	};
 	static const unsigned char yaml[] =
 		"key:\n"
@@ -1363,11 +1363,11 @@ static bool test_err_save_schema_bad_data_size_4(
 	enum test_e {
 		FIRST, SECOND, THIRD, FOURTH, COUNT
 	};
-	static const char *strings[COUNT] = {
-		[FIRST]  = "first",
-		[SECOND] = "second",
-		[THIRD]  = "third",
-		[FOURTH] = "fourth"
+	static const cyaml_strval_t strings[COUNT] = {
+		[FIRST]  = { "first",  0 },
+		[SECOND] = { "second", 1 },
+		[THIRD]  = { "third",  2 },
+		[FOURTH] = { "fourth", 3 },
 	};
 	static const struct target_struct {
 		enum test_e value;
@@ -1488,8 +1488,11 @@ static bool test_err_save_schema_bad_data_size_6(
 		THIRD  = (1 << 2),
 		FOURTH = (1 << 3),
 	};
-	static const char * const strings[] = {
-		"first", "second", "third", "fourth"
+	static const cyaml_strval_t strings[] = {
+		{ "first",  (1 << 0) },
+		{ "second", (1 << 1) },
+		{ "third",  (1 << 2) },
+		{ "fourth", (1 << 3) },
 	};
 	static const struct target_struct {
 		enum test_f value;
@@ -1950,13 +1953,13 @@ static bool test_err_load_schema_invalid_value_flags_1(
 		TEST_FLAGS_FIFTH  = (1 << 4),
 		TEST_FLAGS_SIXTH  = (1 << 5),
 	};
-	static const char * const strings[] = {
-		"first",
-		"second",
-		"third",
-		"fourth",
-		"fifth",
-		"sixth",
+	static const cyaml_strval_t strings[] = {
+		{ "first",  (1 << 0) },
+		{ "second", (1 << 1) },
+		{ "third",  (1 << 2) },
+		{ "fourth", (1 << 3) },
+		{ "fifth",  (1 << 4) },
+		{ "sixth",  (1 << 5) },
 	};
 	static const unsigned char yaml[] =
 		"key:\n"
@@ -2017,13 +2020,13 @@ static bool test_err_load_schema_invalid_value_flags_2(
 		TEST_FLAGS_FIFTH  = (1 << 4),
 		TEST_FLAGS_SIXTH  = (1 << 5),
 	};
-	static const char * const strings[] = {
-		"first",
-		"second",
-		"third",
-		"fourth",
-		"fifth",
-		"sixth",
+	static const cyaml_strval_t strings[] = {
+		{ "first",  (1 << 0) },
+		{ "second", (1 << 1) },
+		{ "third",  (1 << 2) },
+		{ "fourth", (1 << 3) },
+		{ "fifth",  (1 << 4) },
+		{ "sixth",  (1 << 5) },
 	};
 	static const unsigned char yaml[] =
 		"key:\n"
@@ -2084,13 +2087,13 @@ static bool test_err_load_schema_invalid_value_flags_3(
 		TEST_FLAGS_FIFTH  = (1 << 4),
 		TEST_FLAGS_SIXTH  = (1 << 5),
 	};
-	static const char * const strings[] = {
-		"first",
-		"second",
-		"third",
-		"fourth",
-		"fifth",
-		"sixth",
+	static const cyaml_strval_t strings[] = {
+		{ "first",  (1 << 0) },
+		{ "second", (1 << 1) },
+		{ "third",  (1 << 2) },
+		{ "fourth", (1 << 3) },
+		{ "fifth",  (1 << 4) },
+		{ "sixth",  (1 << 5) },
 	};
 	static const unsigned char yaml[] =
 		"key:\n"
@@ -3109,13 +3112,13 @@ static bool test_err_load_schema_flags_mapping(
 		TEST_FLAGS_FIFTH  = (1 << 4),
 		TEST_FLAGS_SIXTH  = (1 << 5),
 	};
-	static const char * const strings[] = {
-		"first",
-		"second",
-		"third",
-		"fourth",
-		"fifth",
-		"sixth",
+	static const cyaml_strval_t strings[] = {
+		{ "first",  (1 << 0) },
+		{ "second", (1 << 1) },
+		{ "third",  (1 << 2) },
+		{ "fourth", (1 << 3) },
+		{ "fifth",  (1 << 4) },
+		{ "sixth",  (1 << 5) },
 	};
 	static const unsigned char yaml[] =
 		"key:\n"
@@ -3175,10 +3178,10 @@ static bool test_err_load_schema_enum_bad_string(
 		TEST_ENUM_THIRD,
 		TEST_ENUM__COUNT,
 	};
-	static const char * const strings[TEST_ENUM__COUNT] = {
-		[TEST_ENUM_FIRST]  = "first",
-		[TEST_ENUM_SECOND] = "second",
-		[TEST_ENUM_THIRD]  = "third",
+	static const cyaml_strval_t strings[TEST_ENUM__COUNT] = {
+		[TEST_ENUM_FIRST]  = { "first",  0 },
+		[TEST_ENUM_SECOND] = { "second", 1 },
+		[TEST_ENUM_THIRD]  = { "third",  2 },
 	};
 	static const unsigned char yaml[] =
 		"key: fourth\n";
@@ -3237,13 +3240,13 @@ static bool test_err_load_schema_flags_bad_string(
 		TEST_FLAGS_FIFTH  = (1 << 4),
 		TEST_FLAGS_SIXTH  = (1 << 5),
 	};
-	static const char * const strings[] = {
-		"first",
-		"second",
-		"third",
-		"fourth",
-		"fifth",
-		"sixth",
+	static const cyaml_strval_t strings[] = {
+		{ "first",  (1 << 0) },
+		{ "second", (1 << 1) },
+		{ "third",  (1 << 2) },
+		{ "fourth", (1 << 3) },
+		{ "fifth",  (1 << 4) },
+		{ "sixth",  (1 << 5) },
 	};
 	static const unsigned char yaml[] =
 		"key:\n"
@@ -3301,10 +3304,10 @@ static bool test_err_save_schema_strict_enum_bad_value(
 		TEST_ENUM_THIRD,
 		TEST_ENUM__COUNT,
 	};
-	static const char * const strings[TEST_ENUM__COUNT] = {
-		[TEST_ENUM_FIRST]  = "first",
-		[TEST_ENUM_SECOND] = "second",
-		[TEST_ENUM_THIRD]  = "third",
+	static const cyaml_strval_t strings[TEST_ENUM__COUNT] = {
+		[TEST_ENUM_FIRST]  = { "first",  0 },
+		[TEST_ENUM_SECOND] = { "second", 1 },
+		[TEST_ENUM_THIRD]  = { "third",  2 },
 	};
 	struct target_struct {
 		enum test_enum a;
@@ -3361,10 +3364,10 @@ static bool test_err_load_schema_strict_enum_bad_string(
 		TEST_ENUM_THIRD,
 		TEST_ENUM__COUNT,
 	};
-	static const char * const strings[TEST_ENUM__COUNT] = {
-		[TEST_ENUM_FIRST]  = "first",
-		[TEST_ENUM_SECOND] = "second",
-		[TEST_ENUM_THIRD]  = "third",
+	static const cyaml_strval_t strings[TEST_ENUM__COUNT] = {
+		[TEST_ENUM_FIRST]  = { "first",  0 },
+		[TEST_ENUM_SECOND] = { "second", 1 },
+		[TEST_ENUM_THIRD]  = { "third",  2 },
 	};
 	static const unsigned char yaml[] =
 		"key: fourth\n";
@@ -3423,13 +3426,13 @@ static bool test_err_save_schema_strict_flags_bad_value(
 		TEST_FLAGS_FIFTH  = (1 << 4),
 		TEST_FLAGS_SIXTH  = (1 << 5),
 	};
-	static const char * const strings[] = {
-		"first",
-		"second",
-		"third",
-		"fourth",
-		"fifth",
-		"sixth",
+	static const cyaml_strval_t strings[] = {
+		{ "first",  (1 << 0) },
+		{ "second", (1 << 1) },
+		{ "third",  (1 << 2) },
+		{ "fourth", (1 << 3) },
+		{ "fifth",  (1 << 4) },
+		{ "sixth",  (1 << 5) },
 	};
 	struct target_struct {
 		enum test_flags a;
@@ -3489,13 +3492,13 @@ static bool test_err_load_schema_strict_flags_bad_string(
 		TEST_FLAGS_FIFTH  = (1 << 4),
 		TEST_FLAGS_SIXTH  = (1 << 5),
 	};
-	static const char * const strings[] = {
-		"first",
-		"second",
-		"third",
-		"fourth",
-		"fifth",
-		"sixth",
+	static const cyaml_strval_t strings[] = {
+		{ "first",  (1 << 0) },
+		{ "second", (1 << 1) },
+		{ "third",  (1 << 2) },
+		{ "fourth", (1 << 3) },
+		{ "fifth",  (1 << 4) },
+		{ "sixth",  (1 << 5) },
 	};
 	static const unsigned char yaml[] =
 		"key:\n"
@@ -3690,13 +3693,13 @@ static bool test_err_load_schema_expect_flags_read_scalar(
 		ttest_report_ctx_t *report,
 		const cyaml_config_t *config)
 {
-	static const char * const strings[] = {
-		"first",
-		"second",
-		"third",
-		"fourth",
-		"fifth",
-		"sixth",
+	static const cyaml_strval_t strings[] = {
+		{ "first",  (1 << 0) },
+		{ "second", (1 << 1) },
+		{ "third",  (1 << 2) },
+		{ "fourth", (1 << 3) },
+		{ "fifth",  (1 << 4) },
+		{ "sixth",  (1 << 5) },
 	};
 	static const unsigned char yaml[] =
 		"key: first\n";
@@ -4048,8 +4051,11 @@ static bool test_err_load_alloc_oom_2(
 		THIRD  = (1 << 2),
 		FOURTH = (1 << 3),
 	};
-	static const char * const strings[] = {
-		"first", "second", "third", "fourth"
+	static const cyaml_strval_t strings[] = {
+		{ "first",  (1 << 0) },
+		{ "second", (1 << 1) },
+		{ "third",  (1 << 2) },
+		{ "fourth", (1 << 3) },
 	};
 	cyaml_config_t cfg = *config;
 	static const unsigned char yaml[] =
@@ -4306,8 +4312,11 @@ static bool test_err_save_alloc_oom_2(
 		THIRD  = (1 << 2),
 		FOURTH = (1 << 3),
 	};
-	static const char * const strings[] = {
-		"first", "second", "third", "fourth"
+	static const cyaml_strval_t strings[] = {
+		{ "first",  (1 << 0) },
+		{ "second", (1 << 1) },
+		{ "third",  (1 << 2) },
+		{ "fourth", (1 << 3) },
 	};
 	cyaml_config_t cfg = *config;
 	static const unsigned char yaml[] =
@@ -4450,8 +4459,12 @@ static bool test_err_load_flag_value_alias(
 		unsigned a;
 		unsigned b;
 	};
-	static const char *str[] = {
-		"one", "two", "three", "four", "five"
+	static const cyaml_strval_t str[] = {
+		{ "one",   (1 << 0) },
+		{ "two",   (1 << 1) },
+		{ "three", (1 << 2) },
+		{ "four",  (1 << 3) },
+		{ "five",  (1 << 4) },
 	};
 	static const unsigned char yaml[] =
 		"a: \n"

--- a/test/units/load.c
+++ b/test/units/load.c
@@ -410,10 +410,10 @@ static bool test_load_mapping_entry_enum(
 		TEST_ENUM_THIRD,
 		TEST_ENUM__COUNT,
 	} value = TEST_ENUM_SECOND;
-	static const char * const strings[TEST_ENUM__COUNT] = {
-		[TEST_ENUM_FIRST]  = "first",
-		[TEST_ENUM_SECOND] = "second",
-		[TEST_ENUM_THIRD]  = "third",
+	static const cyaml_strval_t strings[TEST_ENUM__COUNT] = {
+		[TEST_ENUM_FIRST]  = { "first",  0 },
+		[TEST_ENUM_SECOND] = { "second", 1 },
+		[TEST_ENUM_THIRD]  = { "third",  2 },
 	};
 	static const unsigned char yaml[] =
 		"test_enum: second\n";
@@ -676,13 +676,13 @@ static bool test_load_mapping_entry_flags(
 		TEST_FLAGS_SIXTH  = (1 << 5),
 	} value = TEST_FLAGS_SECOND | TEST_FLAGS_FIFTH | 1024;
 	#define TEST_FLAGS__COUNT 6
-	static const char * const strings[TEST_FLAGS__COUNT] = {
-		"first",
-		"second",
-		"third",
-		"fourth",
-		"fifth",
-		"sixth",
+	static const cyaml_strval_t strings[TEST_FLAGS__COUNT] = {
+		{ "first",  (1 << 0) },
+		{ "second", (1 << 1) },
+		{ "third",  (1 << 2) },
+		{ "fourth", (1 << 3) },
+		{ "fifth",  (1 << 4) },
+		{ "sixth",  (1 << 5) },
 	};
 	static const unsigned char yaml[] =
 		"test_flags:\n"
@@ -747,13 +747,13 @@ static bool test_load_mapping_entry_flags_empty(
 		TEST_FLAGS_SIXTH  = (1 << 5),
 	} value = TEST_FLAGS_NONE;
 	#define TEST_FLAGS__COUNT 6
-	static const char * const strings[TEST_FLAGS__COUNT] = {
-		"first",
-		"second",
-		"third",
-		"fourth",
-		"fifth",
-		"sixth",
+	static const cyaml_strval_t strings[TEST_FLAGS__COUNT] = {
+		{ "first",  (1 << 0) },
+		{ "second", (1 << 1) },
+		{ "third",  (1 << 2) },
+		{ "fourth", (1 << 3) },
+		{ "fifth",  (1 << 4) },
+		{ "sixth",  (1 << 5) },
 	};
 	static const unsigned char yaml[] =
 		"test_flags: []\n";
@@ -1004,10 +1004,10 @@ static bool test_load_mapping_entry_sequence_enum(
 		TEST_ENUM_THIRD,
 		TEST_ENUM__COUNT,
 	} ref[] = { TEST_ENUM_FIRST, TEST_ENUM_SECOND, TEST_ENUM_THIRD };
-	static const char * const strings[TEST_ENUM__COUNT] = {
-		[TEST_ENUM_FIRST]  = "first",
-		[TEST_ENUM_SECOND] = "second",
-		[TEST_ENUM_THIRD]  = "third",
+	static const cyaml_strval_t strings[TEST_ENUM__COUNT] = {
+		[TEST_ENUM_FIRST]  = { "first",  0 },
+		[TEST_ENUM_SECOND] = { "second", 1 },
+		[TEST_ENUM_THIRD]  = { "third",  2 },
 	};
 	static const unsigned char yaml[] =
 		"sequence:\n"
@@ -1223,13 +1223,13 @@ static bool test_load_mapping_entry_sequence_flags(
 		TEST_FLAGS_FOURTH | TEST_FLAGS_SIXTH
 	};
 	#define TEST_FLAGS__COUNT 6
-	static const char * const strings[TEST_FLAGS__COUNT] = {
-		"first",
-		"second",
-		"third",
-		"fourth",
-		"fifth",
-		"sixth",
+	static const cyaml_strval_t strings[TEST_FLAGS__COUNT] = {
+		{ "first",  (1 << 0) },
+		{ "second", (1 << 1) },
+		{ "third",  (1 << 2) },
+		{ "fourth", (1 << 3) },
+		{ "fifth",  (1 << 4) },
+		{ "sixth",  (1 << 5) },
 	};
 	static const unsigned char yaml[] =
 		"sequence:\n"
@@ -1932,10 +1932,10 @@ static bool test_load_mapping_entry_sequence_ptr_enum(
 		TEST_ENUM_THIRD,
 		TEST_ENUM__COUNT,
 	} ref[] = { TEST_ENUM_FIRST, TEST_ENUM_SECOND, TEST_ENUM_THIRD };
-	static const char * const strings[TEST_ENUM__COUNT] = {
-		[TEST_ENUM_FIRST]  = "first",
-		[TEST_ENUM_SECOND] = "second",
-		[TEST_ENUM_THIRD]  = "third",
+	static const cyaml_strval_t strings[TEST_ENUM__COUNT] = {
+		[TEST_ENUM_FIRST]  = { "first",  0 },
+		[TEST_ENUM_SECOND] = { "second", 1 },
+		[TEST_ENUM_THIRD]  = { "third",  2 },
 	};
 	static const unsigned char yaml[] =
 		"sequence:\n"
@@ -2151,13 +2151,13 @@ static bool test_load_mapping_entry_sequence_ptr_flags(
 		TEST_FLAGS_FOURTH | TEST_FLAGS_SIXTH
 	};
 	#define TEST_FLAGS__COUNT 6
-	static const char * const strings[TEST_FLAGS__COUNT] = {
-		"first",
-		"second",
-		"third",
-		"fourth",
-		"fifth",
-		"sixth",
+	static const cyaml_strval_t strings[TEST_FLAGS__COUNT] = {
+		{ "first",  (1 << 0) },
+		{ "second", (1 << 1) },
+		{ "third",  (1 << 2) },
+		{ "fourth", (1 << 3) },
+		{ "fifth",  (1 << 4) },
+		{ "sixth",  (1 << 5) },
 	};
 	static const unsigned char yaml[] =
 		"sequence:\n"

--- a/test/units/save.c
+++ b/test/units/save.c
@@ -621,11 +621,11 @@ static bool test_save_mapping_entry_enum_strict(
 	enum test_e {
 		FIRST, SECOND, THIRD, FOURTH, COUNT
 	};
-	static const char *strings[COUNT] = {
-		[FIRST]  = "first",
-		[SECOND] = "second",
-		[THIRD]  = "third",
-		[FOURTH] = "fourth"
+	static const cyaml_strval_t strings[COUNT] = {
+		{ "first",  0 },
+		{ "second", 1 },
+		{ "third",  2 },
+		{ "fourth", 3 },
 	};
 	static const unsigned char ref[] =
 		"---\n"
@@ -686,8 +686,11 @@ static bool test_save_mapping_entry_enum_number(
 	enum test_e {
 		FIRST, SECOND, THIRD, FOURTH
 	};
-	static const char *strings[] = {
-		"first", "second", "third", "fourth"
+	static const cyaml_strval_t strings[] = {
+		{ "first",  0 },
+		{ "second", 1 },
+		{ "third",  2 },
+		{ "fourth", 3 },
 	};
 	static const unsigned char ref[] =
 		"---\n"
@@ -894,8 +897,11 @@ static bool test_save_mapping_entry_flags_strict(
 		THIRD  = (1 << 2),
 		FOURTH = (1 << 3),
 	};
-	static const char * const strings[] = {
-		"first", "second", "third", "fourth"
+	static const cyaml_strval_t strings[] = {
+		{ "first",  (1 << 0) },
+		{ "second", (1 << 1) },
+		{ "third",  (1 << 2) },
+		{ "fourth", (1 << 3) },
 	};
 	static const unsigned char ref[] =
 		"---\n"
@@ -962,8 +968,11 @@ static bool test_save_mapping_entry_flags_number(
 		THIRD  = (1 << 2),
 		FOURTH = (1 << 3),
 	};
-	static const char *strings[] = {
-		"first", "second", "third", "fourth"
+	static const cyaml_strval_t strings[] = {
+		{ "first",  (1 << 0) },
+		{ "second", (1 << 1) },
+		{ "third",  (1 << 2) },
+		{ "fourth", (1 << 3) },
 	};
 	static const unsigned char ref[] =
 		"---\n"
@@ -1166,10 +1175,10 @@ static bool test_save_mapping_entry_sequence_enum(
 		TEST_ENUM_THIRD,
 		TEST_ENUM__COUNT,
 	};
-	static const char * const strings[TEST_ENUM__COUNT] = {
-		[TEST_ENUM_FIRST]  = "first",
-		[TEST_ENUM_SECOND] = "second",
-		[TEST_ENUM_THIRD]  = "third",
+	static const cyaml_strval_t strings[TEST_ENUM__COUNT] = {
+		[TEST_ENUM_FIRST]  = { "first",  0 },
+		[TEST_ENUM_SECOND] = { "second", 1 },
+		[TEST_ENUM_THIRD]  = { "third",  2 },
 	};
 	static const unsigned char ref[] =
 		"---\n"
@@ -1316,14 +1325,14 @@ static bool test_save_mapping_entry_sequence_flags(
 		TEST_FLAGS_FIFTH  = (1 << 4),
 		TEST_FLAGS_SIXTH  = (1 << 5),
 	};
-	#define TEST_FLAGS__COUNT 6
-	static const char * const strings[TEST_FLAGS__COUNT] = {
-		"first",
-		"second",
-		"third",
-		"fourth",
-		"fifth",
-		"sixth",
+	static const cyaml_strval_t strings[] = {
+		{ "none",   TEST_FLAGS_NONE },
+		{ "first",  TEST_FLAGS_FIRST },
+		{ "second", TEST_FLAGS_SECOND },
+		{ "third",  TEST_FLAGS_THIRD },
+		{ "fourth", TEST_FLAGS_FOURTH },
+		{ "fifth",  TEST_FLAGS_FIFTH },
+		{ "sixth",  TEST_FLAGS_SIXTH },
 	};
 	static const unsigned char ref[] =
 		"---\n"
@@ -1347,7 +1356,7 @@ static bool test_save_mapping_entry_sequence_flags(
 	};
 	static const struct cyaml_schema_value entry_schema = {
 		CYAML_VALUE_FLAGS(CYAML_FLAG_DEFAULT, *(data.seq),
-				strings, TEST_FLAGS__COUNT),
+				strings, CYAML_ARRAY_LEN(strings)),
 	};
 	static const struct cyaml_schema_field mapping_schema[] = {
 		CYAML_FIELD_SEQUENCE("sequence", CYAML_FLAG_DEFAULT,
@@ -2125,10 +2134,10 @@ static bool test_save_mapping_entry_sequence_ptr_enum(
 		TEST_ENUM_THIRD,
 		TEST_ENUM__COUNT,
 	};
-	static const char * const strings[TEST_ENUM__COUNT] = {
-		[TEST_ENUM_FIRST]  = "first",
-		[TEST_ENUM_SECOND] = "second",
-		[TEST_ENUM_THIRD]  = "third",
+	static const cyaml_strval_t strings[TEST_ENUM__COUNT] = {
+		[TEST_ENUM_FIRST]  = { "first",  0 },
+		[TEST_ENUM_SECOND] = { "second", 1 },
+		[TEST_ENUM_THIRD]  = { "third",  2 },
 	};
 	static const unsigned char ref[] =
 		"---\n"
@@ -2284,14 +2293,14 @@ static bool test_save_mapping_entry_sequence_ptr_flags(
 		TEST_FLAGS_FIFTH  = (1 << 4),
 		TEST_FLAGS_SIXTH  = (1 << 5),
 	};
-	#define TEST_FLAGS__COUNT 6
-	static const char * const strings[TEST_FLAGS__COUNT] = {
-		"first",
-		"second",
-		"third",
-		"fourth",
-		"fifth",
-		"sixth",
+	static const cyaml_strval_t strings[] = {
+		{ "none",   TEST_FLAGS_NONE },
+		{ "first",  TEST_FLAGS_FIRST },
+		{ "second", TEST_FLAGS_SECOND },
+		{ "third",  TEST_FLAGS_THIRD },
+		{ "fourth", TEST_FLAGS_FOURTH },
+		{ "fifth",  TEST_FLAGS_FIFTH },
+		{ "sixth",  TEST_FLAGS_SIXTH },
 	};
 	static const unsigned char ref[] =
 		"---\n"
@@ -2317,7 +2326,7 @@ static bool test_save_mapping_entry_sequence_ptr_flags(
 	};
 	static const struct cyaml_schema_value entry_schema = {
 		CYAML_VALUE_FLAGS(CYAML_FLAG_DEFAULT, *(data.seq),
-				strings, TEST_FLAGS__COUNT),
+				strings, CYAML_ARRAY_LEN(strings)),
 	};
 	static const struct cyaml_schema_field mapping_schema[] = {
 		CYAML_FIELD_SEQUENCE("sequence", CYAML_FLAG_POINTER,
@@ -3267,10 +3276,9 @@ static bool test_save_mapping_value_block_style(
 	};
 	char *buffer = NULL;
 	size_t len = 0;
-	cyaml_config_t cfg = *config;
 	test_data_t td = {
 		.buffer = &buffer,
-		.config = &cfg,
+		.config = config,
 	};
 	cyaml_err_t err;
 


### PR DESCRIPTION
Previously non-continuous enum and flag values had a sub-optimal schema representation.