### PR TITLE
API: Allow client mem_fn to have a private allocation context pointer.

### DIFF
--- a/include/cyaml/cyaml.h
+++ b/include/cyaml/cyaml.h
@@ -982,6 +982,7 @@ typedef void (*cyaml_log_fn_t)(
  *
  * Clients may implement this to handle memory allocation / freeing.
  *
+ * \param[in] ctx    Client's private allocation context.
  * \param[in] ptr    Existing allocation to resize, or NULL.
  * \param[in] size   The new size for the allocation.  \note setting 0 must
  *                   be treated as free().
@@ -991,6 +992,7 @@ typedef void (*cyaml_log_fn_t)(
  *         invalid.
  */
 typedef void * (*cyaml_mem_fn_t)(
+		void *ctx,
 		void *ptr,
 		size_t size);
 
@@ -1027,6 +1029,16 @@ typedef struct cyaml_config {
 	 *       is freed using \ref cyaml_mem too.
 	 */
 	cyaml_mem_fn_t mem_fn;
+	/**
+	 * Client memory function context pointer.
+	 *
+	 * Clients using their own custom allocation function can pass their
+	 * context here, which will be passed through to their mem_fn.
+	 *
+	 * The default allocation function, \ref cyaml_mem doesn't require an
+	 * allocation context, so pass NULL for the mem_ctx if using that.
+	 */
+	void *mem_ctx;
 	/**
 	 * Minimum logging priority level to be issued.
 	 *
@@ -1069,6 +1081,7 @@ extern void cyaml_log(
  * to allocate/free memory when they have not provided their own allocation
  * function.
  *
+ * \param[in] ctx    Allocation context, unused.
  * \param[in] ptr    Existing allocation to resize, or NULL.
  * \param[in] size   The new size for the allocation.  \note When `size == 0`
  *                   this frees `ptr`.
@@ -1078,6 +1091,7 @@ extern void cyaml_log(
  *         invalid.
  */
 extern void * cyaml_mem(
+		void *ctx,
 		void *ptr,
 		size_t size);
 
@@ -1168,7 +1182,7 @@ extern cyaml_err_t cyaml_save_file(
  *         // Use `yaml`:
  *         printf("%*s\n", len, yaml);
  *         // Free `yaml`:
- *         config.mem_fn(yaml, 0);
+ *         config.mem_fn(config.mem_ctx, yaml, 0);
  * }
  * ```
  *

--- a/src/mem.c
+++ b/src/mem.c
@@ -17,11 +17,17 @@
 
 #include "mem.h"
 
+/** Macro to squash unused variable compiler warnings. */
+#define CYAML_UNUSED(_x) ((void)(_x))
+
 /* Exported function, documented in include/cyaml/cyaml.h */
 void * cyaml_mem(
+		void *ctx,
 		void *ptr,
 		size_t size)
 {
+	CYAML_UNUSED(ctx);
+
 	if (size == 0) {
 		free(ptr);
 		return NULL;

--- a/src/mem.h
+++ b/src/mem.h
@@ -24,7 +24,7 @@ static inline void cyaml__free(
 		const cyaml_config_t *config,
 		void *ptr)
 {
-	config->mem_fn(ptr, 0);
+	config->mem_fn(config->mem_ctx, ptr, 0);
 }
 
 /**
@@ -50,7 +50,7 @@ static inline void * cyaml__realloc(
 		size_t new_size,
 		bool clean)
 {
-	uint8_t *temp = config->mem_fn(ptr, new_size);
+	uint8_t *temp = config->mem_fn(config->mem_ctx, ptr, new_size);
 	if (temp == NULL) {
 		return NULL;
 	}

--- a/test/units/save.c
+++ b/test/units/save.c
@@ -42,7 +42,7 @@ static void cyaml_cleanup(void *data)
 	struct test_data *td = data;
 
 	if (td->config->mem_fn != NULL && td->buffer != NULL) {
-		td->config->mem_fn(*(td->buffer), 0);
+		td->config->mem_fn(td->config->mem_ctx, *(td->buffer), 0);
 	}
 }
 


### PR DESCRIPTION
This changes the cyaml config struct to take a `mem_ctx` void pointer, which is passed to the `mem_fn`, allowing clients to have more control over memory allocation pools.