### PR TITLE
Tlsa/strcasecmp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ LIB_SHARED = libcyaml.so
 LIB_SH_VER = $(LIB_SHARED).$(VERSION_STR)
 
 TEST_SRC_FILES = units/free.c units/load.c units/test.c units/util.c \
-		units/errs.c units/file.c units/save.c
+		units/errs.c units/file.c units/save.c units/utf8.c
 TEST_SRC := $(addprefix test/,$(TEST_SRC_FILES))
 TEST_OBJ = $(patsubst %.c,%.o, $(addprefix $(BUILDDIR)/,$(TEST_SRC)))
 

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ endif
 BUILDDIR_SHARED = $(BUILDDIR)/shared
 BUILDDIR_STATIC = $(BUILDDIR)/static
 
-LIB_SRC_FILES = mem.c free.c load.c save.c util.c
+LIB_SRC_FILES = mem.c free.c load.c save.c util.c utf8.c
 LIB_SRC := $(addprefix src/,$(LIB_SRC_FILES))
 LIB_OBJ = $(patsubst %.c,%.o, $(addprefix $(BUILDDIR)/,$(LIB_SRC)))
 LIB_OBJ_SHARED = $(patsubst $(BUILDDIR)%,$(BUILDDIR_SHARED)%,$(LIB_OBJ))

--- a/include/cyaml/cyaml.h
+++ b/include/cyaml/cyaml.h
@@ -158,6 +158,42 @@ typedef enum cyaml_flag {
 	 *       then libyaml's default behaviour is used.
 	 */
 	CYAML_FLAG_FLOW     = (1 << 4),
+	/**
+	 * When comparing strings for this value, compare with case sensitivity.
+	 *
+	 * By default, strings are compared with case sensitivity.
+	 * If \ref CYAML_CFG_CASE_INSENSITIVE is set, this can override
+	 * the configured behaviour for this specific value.
+	 *
+	 * \note If both \ref CYAML_FLAG_CASE_SENSITIVE and
+	 *       \ref CYAML_FLAG_CASE_INSENSITIVE are set,
+	 *       then case insensitive takes precedence.
+	 *
+	 * \note This applies to values of types \ref CYAML_MAPPING,
+	 *       \ref CYAML_ENUM, and \ref CYAML_FLAGS.  For mappings,
+	 *       it applies to matching of the mappings' keys.  For
+	 *       enums and flags it applies to the comparison of
+	 *       \ref struct cyaml_strval strings.
+	 */
+	CYAML_FLAG_CASE_SENSITIVE   = (1 << 5),
+	/**
+	 * When comparing strings for this value, compare with case sensitivity.
+	 *
+	 * By default, strings are compared with case sensitivity.
+	 * If \ref CYAML_CFG_CASE_INSENSITIVE is set, this can override
+	 * the configured behaviour for this specific value.
+	 *
+	 * \note If both \ref CYAML_FLAG_CASE_SENSITIVE and
+	 *       \ref CYAML_FLAG_CASE_INSENSITIVE are set,
+	 *       then case insensitive takes precedence.
+	 *
+	 * \note This applies to values of types \ref CYAML_MAPPING,
+	 *       \ref CYAML_ENUM, and \ref CYAML_FLAGS.  For mappings,
+	 *       it applies to matching of the mappings' keys.  For
+	 *       enums and flags it applies to the comparison of
+	 *       \ref struct cyaml_strval strings.
+	 */
+	CYAML_FLAG_CASE_INSENSITIVE = (1 << 6),
 } cyaml_flag_e;
 
 /**
@@ -370,6 +406,12 @@ typedef enum cyaml_cfg_flags {
 	 * be emitted.
 	 */
 	CYAML_CFG_DOCUMENT_DELIM      = (1 << 3),
+	/**
+	 * When comparing strings, compare without case sensitivity.
+	 *
+	 * By default, strings are compared with case sensitivity.
+	 */
+	CYAML_CFG_CASE_INSENSITIVE    = (1 << 4),
 } cyaml_cfg_flags_t;
 
 /**

--- a/src/load.c
+++ b/src/load.c
@@ -172,20 +172,22 @@ static cyaml_err_t cyaml_get_next_event(
 /**
  * Get the offset to a mapping field by key in a mapping schema array.
  *
- * \param[in]  mapping_schema  Array of mapping schema fields.
- * \param[in]  key             Key to search for in mapping schema.
- * \return index into `mapping_schema` for key, or \ref CYAML_SCHEMA_IDX_NONE
- *         if key is not present in `mapping_schema`.
+ * \param[in]  ctx  The CYAML loading context.
+ * \param[in]  key  Key to search for in mapping schema.
+ * \return index the mapping schema's mapping fields array for key, or
+ *         \ref CYAML_SCHEMA_IDX_NONE if key is not present in schema.
  */
 static inline uint16_t cyaml__get_entry_from_mapping_schema(
-		const cyaml_schema_field_t * mapping_schema,
+		const cyaml_ctx_t *ctx,
 		const char *key)
 {
+	const cyaml_schema_field_t *fields = ctx->state->mapping.schema;
+	const cyaml_schema_value_t *schema = ctx->state->schema;
 	uint16_t index = 0;
 
 	/* Step through each entry in the schema */
-	for (; mapping_schema->key != NULL; mapping_schema++) {
-		if (strcmp(mapping_schema->key, key) == 0) {
+	for (; fields->key != NULL; fields++) {
+		if (cyaml__strcmp(ctx->config, schema, fields->key, key) == 0) {
 			return index;
 		}
 		index++;
@@ -1285,8 +1287,8 @@ static cyaml_err_t cyaml__map_key(
 	cyaml_err_t err = CYAML_OK;
 
 	key = (const char *)event->data.scalar.value;
-	ctx->state->mapping.schema_idx = cyaml__get_entry_from_mapping_schema(
-			ctx->state->mapping.schema, key);
+	ctx->state->mapping.schema_idx =
+			cyaml__get_entry_from_mapping_schema(ctx, key);
 	cyaml__log(ctx->config, CYAML_LOG_INFO, "[%s]\n", key);
 
 	if (ctx->state->mapping.schema_idx == CYAML_SCHEMA_IDX_NONE) {

--- a/src/load.c
+++ b/src/load.c
@@ -737,7 +737,8 @@ static cyaml_err_t cyaml__read_enum(
 	const cyaml_strval_t *strings = schema->enumeration.strings;
 
 	for (uint32_t i = 0; i < schema->enumeration.count; i++) {
-		if (strcmp(value, strings[i].str) == 0) {
+		if (cyaml__strcmp(ctx->config, schema,
+				value, strings[i].str) == 0) {
 			return cyaml_data_write(strings[i].val,
 					schema->data_size, data);
 		}
@@ -961,7 +962,8 @@ static cyaml_err_t cyaml__set_flag(
 	const cyaml_strval_t *strings = schema->enumeration.strings;
 
 	for (uint32_t i = 0; i < schema->enumeration.count; i++) {
-		if (strcmp(value, strings[i].str) == 0) {
+		if (cyaml__strcmp(ctx->config, schema,
+				value, strings[i].str) == 0) {
 			*flags_out |= strings[i].val;
 			return CYAML_OK;
 		}

--- a/src/load.c
+++ b/src/load.c
@@ -207,9 +207,9 @@ static inline uint16_t cyaml__get_entry_from_mapping_schema(
  * \return Current mapping field's schema entry.
  */
 static inline const cyaml_schema_field_t * cyaml_mapping_schema_field(
-		cyaml_ctx_t *ctx)
+		const cyaml_ctx_t *ctx)
 {
-	cyaml_state_t *state = ctx->state;
+	const cyaml_state_t *state = ctx->state;
 
 	assert(state != NULL);
 	assert(state->state == CYAML_STATE_IN_MAP_KEY ||

--- a/src/utf8.c
+++ b/src/utf8.c
@@ -1,0 +1,225 @@
+/*
+ * SPDX-License-Identifier: ISC
+ *
+ * Copyright (C) 2018 Michael Drake <tlsa@netsurf-browser.org>
+ */
+
+/**
+ * \file
+ * \brief CYAML functions for handling utf8 text.
+ */
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "utf8.h"
+
+/**
+ * Get expected byte-length of UTF8 character.
+ *
+ * Finds the number of bytes expected for the UTF8 sequence starting with
+ * the given byte.
+ *
+ * \param[in]  b  First byte of UTF8 sequence.
+ * \return the byte width of the character or 0 if invalid.
+ */
+static inline int cyaml_utf8_char_len(uint8_t b)
+{
+	if (!(b & 0x80)) {
+		return 1;
+	} else switch (b >> 3) {
+		case 0x18:
+		case 0x19:
+		case 0x1a:
+		case 0x1b:
+			return 2;
+		case 0x1c:
+		case 0x1d:
+			return 3;
+		case 0x1e:
+			return 4;
+	}
+	return 0; /* Invalid */
+}
+
+/**
+ * Get a codepoint from the input string.
+ *
+ * Caller must provide the expected length given the first input byte.
+ *
+ * \param[in]  s    String to read first codepoint from.
+ * \param[in]  len  Expected length of first character.
+ * \return The codepoint or `0xfffd` if character is invalid.
+ */
+static unsigned cyaml_utf8_get_codepoint(
+		const uint8_t *s,
+		int len)
+{
+	if (len > 1) {
+		assert(s[0] != 0);
+	}
+
+	switch (len) {
+	case 1:
+		return s[0];
+	case 2:
+		if (s[1] == 0) {
+			break;
+		}
+		return ((0x1f & s[0]) <<  6) |  (0x3f & s[1]);
+	case 3:
+		if ((s[1] == 0) || (s[2] == 0)) {
+			break;
+		}
+		return ((0x0f & s[0]) << 12) | ((0x3f & s[1]) <<  6) |
+		        (0x3f & s[2]);
+	case 4:
+		if ((s[1] == 0) || (s[2] == 0) || (s[3] == 0)) {
+			break;
+		}
+		return ((0x07 & s[0]) << 18) | ((0x3f & s[1]) << 12) |
+		       ((0x3f & s[2]) <<  6) |  (0x3f & s[3]);
+	}
+
+	/* Invalid. */
+	return 0xfffd; /* REPLACEMENT CHARACTER */
+}
+
+/**
+ * Convert a Unicode codepoint to lower case.
+ *
+ * \note This only handles some of the Unicode blocks.
+ *       (Currently the Latin ones.)
+ *
+ * \param[in]  c  Codepoint to convert to lower-case, if applicable.
+ * \return the lower-cased codepoint.
+ */
+static unsigned cyaml_utf8_to_lower(unsigned c)
+{
+	if (((c >= 0x0041) && (c <= 0x005a)) /* Basic Latin */        ||
+	    ((c >= 0x00c0) && (c <= 0x00d6)) /* Latin-1 Supplement */ ||
+	    ((c >= 0x00d8) && (c <= 0x00de)) /* Latin-1 Supplement */ ) {
+		return c + 32;
+
+	} else if (((c >= 0x0100) && (c <= 0x012f)) /* Latin Extended-A */ ||
+	           ((c >= 0x0132) && (c <= 0x0137)) /* Latin Extended-A */ ||
+	           ((c >= 0x014a) && (c <= 0x0177)) /* Latin Extended-A */ ||
+	           ((c >= 0x0182) && (c <= 0x0185)) /* Latin Extended-B */ ||
+	           ((c >= 0x01a0) && (c <= 0x01a5)) /* Latin Extended-B */ ||
+	           ((c >= 0x01de) && (c <= 0x01ef)) /* Latin Extended-B */ ||
+	           ((c >= 0x01f8) && (c <= 0x021f)) /* Latin Extended-B */ ||
+	           ((c >= 0x0222) && (c <= 0x0233)) /* Latin Extended-B */ ||
+	           ((c >= 0x0246) && (c <= 0x024f)) /* Latin Extended-B */ ) {
+		return c & ~0x1;
+
+	} else if (((c >= 0x0139) && (c <= 0x0148) /* Latin Extended-A */) ||
+	           ((c >= 0x0179) && (c <= 0x017e) /* Latin Extended-A */) ||
+	           ((c >= 0x01b3) && (c <= 0x01b6) /* Latin Extended-B */) ||
+	           ((c >= 0x01cd) && (c <= 0x01dc) /* Latin Extended-B */)) {
+		return (c + 1) & ~0x1;
+
+	} else switch (c) {
+		case 0x0178: return 0x00ff; /* Latin Extended-A */
+		case 0x0187: return 0x0188; /* Latin Extended-B */
+		case 0x018b: return 0x018c; /* Latin Extended-B */
+		case 0x018e: return 0x01dd; /* Latin Extended-B */
+		case 0x0191: return 0x0192; /* Latin Extended-B */
+		case 0x0198: return 0x0199; /* Latin Extended-B */
+		case 0x01a7: return 0x01a8; /* Latin Extended-B */
+		case 0x01ac: return 0x01ad; /* Latin Extended-B */
+		case 0x01af: return 0x01b0; /* Latin Extended-B */
+		case 0x01b7: return 0x0292; /* Latin Extended-B */
+		case 0x01b8: return 0x01b9; /* Latin Extended-B */
+		case 0x01bc: return 0x01bd; /* Latin Extended-B */
+		case 0x01c4: return 0x01c6; /* Latin Extended-B */
+		case 0x01c5: return 0x01c6; /* Latin Extended-B */
+		case 0x01c7: return 0x01c9; /* Latin Extended-B */
+		case 0x01c8: return 0x01c9; /* Latin Extended-B */
+		case 0x01ca: return 0x01cc; /* Latin Extended-B */
+		case 0x01cb: return 0x01cc; /* Latin Extended-B */
+		case 0x01f1: return 0x01f3; /* Latin Extended-B */
+		case 0x01f2: return 0x01f3; /* Latin Extended-B */
+		case 0x01f4: return 0x01f5; /* Latin Extended-B */
+		case 0x01f7: return 0x01bf; /* Latin Extended-B */
+		case 0x0220: return 0x019e; /* Latin Extended-B */
+		case 0x023b: return 0x023c; /* Latin Extended-B */
+		case 0x023d: return 0x019a; /* Latin Extended-B */
+		case 0x0241: return 0x0242; /* Latin Extended-B */
+		case 0x0243: return 0x0180; /* Latin Extended-B */
+	}
+
+	return c;
+}
+
+/* Exported function, documented in utf8.h. */
+int cyaml_utf8_casecmp(
+		const void * const str1,
+		const void * const str2)
+{
+	const uint8_t *s1 = str1;
+	const uint8_t *s2 = str2;
+
+	while (true) {
+		int len1;
+		int len2;
+		int cmp1;
+		int cmp2;
+
+		/* Check for end of strings. */
+		if ((*s1 == 0) && (*s2 == 0)) {
+			return 0; /* Both strings ended; match. */
+
+		} else if (*s1 == 0) {
+			return 1; /* String 1 has ended. */
+
+		} else if (*s2 == 0) {
+			return -1;/* String 2 has ended. */
+		}
+
+		/* Get byte lengths of these characters. */
+		len1 = cyaml_utf8_char_len(*s1);
+		len2 = cyaml_utf8_char_len(*s2);
+
+		/* Compare values. */
+		if ((len1 == 1) && (len2 == 1)) {
+			/* Common case: Both strings have ASCII values. */
+			if (*s1 != *s2) {
+				/* They're different; need to lower case. */
+				cmp1 = ((*s1 >= 'A') && (*s1 <= 'Z')) ?
+						(*s1 + 'a' - 'A') : *s1;
+				cmp2 = ((*s2 >= 'A') && (*s2 <= 'Z')) ?
+						(*s2 + 'a' - 'A') : *s2;
+				if (cmp1 != cmp2) {
+					return cmp1 - cmp2;
+				}
+			}
+		} else if ((len1 == 0) || (len2 == 0)) {
+			/* Invalid UTF8 sequence. */
+			return len1 - len2;
+		} else {
+			/* Otherwise convert to UCS4 for comparison. */
+			cmp1 = cyaml_utf8_get_codepoint(s1, len1);
+			cmp2 = cyaml_utf8_get_codepoint(s2, len2);
+
+			if (cmp1 != cmp2) {
+				/* They're different; need to lower case. */
+				cmp1 = cyaml_utf8_to_lower(cmp1);
+				cmp2 = cyaml_utf8_to_lower(cmp2);
+				if (cmp1 != cmp2) {
+					return cmp1 - cmp2;
+				}
+			}
+		}
+
+		/* Advance each string by their current character length. */
+		while ((*s1 != 0) && len1) {
+			len1--;
+			s1++;
+		}
+		while ((*s2 != 0) && len2) {
+			len2--;
+			s2++;
+		}
+	}
+}

--- a/src/utf8.h
+++ b/src/utf8.h
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: ISC
+ *
+ * Copyright (C) 2018 Michael Drake <tlsa@netsurf-browser.org>
+ */
+
+/**
+ * \file
+ * \brief CYAML functions for handling utf8 text.
+ */
+
+#ifndef CYAML_UTF8_H
+#define CYAML_UTF8_H
+
+/**
+ * Case insensitive comparason.
+ *
+ * \note This has some limitations and only performs case insensitive
+ *       comparason over some sectons of unicode.
+ *
+ * \param[in]  str1  First string to be compared.
+ * \param[in]  str2  Second string to be compared.
+ * \return 0 if and only if strings are equal.
+ */
+int cyaml_utf8_casecmp(
+		const void * const str1,
+		const void * const str2);
+
+#endif

--- a/src/util.c
+++ b/src/util.c
@@ -13,6 +13,7 @@
 #include <stdbool.h>
 #include <stdarg.h>
 #include <stdint.h>
+#include <string.h>
 #include <stdio.h>
 
 #include "util.h"

--- a/src/util.h
+++ b/src/util.h
@@ -13,6 +13,7 @@
 #define CYAML_UTIL_H
 
 #include "cyaml/cyaml.h"
+#include "utf8.h"
 
 /** Macro to squash unused variable compiler warnings. */
 #define CYAML_UNUSED(_x) ((void)(_x))
@@ -76,6 +77,58 @@ static inline void cyaml__log(
 		cfg->log_fn(level, fmt, args);
 		va_end(args);
 	}
+}
+
+/**
+ * Check if comparason should be case sensitive.
+ *
+ * As described in the API, schema flags take priority over config flags.
+ *
+ * \param[in]  config  Client's CYAML configuration structure.
+ * \param[in]  schema  The CYAML schema for the value to be compared.
+ * \return Whether to use case-sensitive comparason.
+ */
+static inline bool cyaml__is_case_sensitive(
+		const cyaml_config_t *config,
+		const cyaml_schema_value_t *schema)
+{
+	if (schema->flags & CYAML_FLAG_CASE_INSENSITIVE) {
+		return false;
+
+	} else if (schema->flags & CYAML_FLAG_CASE_SENSITIVE) {
+		return true;
+
+	} else if (config->flags & CYAML_CFG_CASE_INSENSITIVE) {
+		return false;
+
+	}
+
+	return true;
+}
+
+/**
+ * Compare two strings.
+ *
+ * Depending on the client's configuration, and the value's schema,
+ * this will do either a case-sensitive or case-insensitive comparason.
+ *
+ * \param[in]  config  Client's CYAML configuration structure.
+ * \param[in]  schema  The CYAML schema for the value to be compared.
+ * \param[in]  str1    First string to be compared.
+ * \param[in]  str2    Second string to be compared.
+ * \return 0 if and only if strings are equal.
+ */
+static inline int cyaml__strcmp(
+		const cyaml_config_t *config,
+		const cyaml_schema_value_t *schema,
+		const void * const str1,
+		const void * const str2)
+{
+	if (cyaml__is_case_sensitive(config, schema)) {
+		return strcmp(str1, str2);
+	}
+
+	return cyaml_utf8_casecmp(str1, str2);
 }
 
 #endif

--- a/test/units/test.c
+++ b/test/units/test.c
@@ -34,6 +34,12 @@ extern bool free_tests(
 		cyaml_log_t log_level,
 		cyaml_log_fn_t log_fn);
 
+/** In utf8.c */
+extern bool utf8_tests(
+		ttest_report_ctx_t *rc,
+		cyaml_log_t log_level,
+		cyaml_log_fn_t log_fn);
+
 /** In util.c */
 extern bool util_tests(
 		ttest_report_ctx_t *rc,
@@ -102,6 +108,7 @@ int main(int argc, char *argv[])
 
 	rc = ttest_init(quiet);
 
+	pass &= utf8_tests(&rc, log_level, log_fn);
 	pass &= util_tests(&rc, log_level, log_fn);
 	pass &= free_tests(&rc, log_level, log_fn);
 	pass &= load_tests(&rc, log_level, log_fn);

--- a/test/units/utf8.c
+++ b/test/units/utf8.c
@@ -1,0 +1,217 @@
+/*
+ * SPDX-License-Identifier: ISC
+ *
+ * Copyright (C) 2018 Michael Drake <tlsa@netsurf-browser.org>
+ */
+
+#include <stdbool.h>
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdio.h>
+
+#include <cyaml/cyaml.h>
+
+#include "../../src/utf8.h"
+
+#include "ttest.h"
+
+/** Helper macro to squash unused variable warnings. */
+#define UNUSED(_x) ((void)(_x))
+
+/**
+ * Test comparing the same strings.
+ *
+ * \param[in]  report  The test report context.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_utf8_strcmp_same(
+		ttest_report_ctx_t *report)
+{
+	const char *strings[] = {
+		"Simple",
+		"test",
+		"This is a LONGER string, if you see what I mean.",
+		"29087   lsdkfj  </,.{}'#\"|@>",
+		u8"ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞß",
+		u8"àáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ",
+		u8"¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿",
+		"\xc3\0",
+		u8"αβγδε",
+		u8"¯\\_(ツ)_/¯",
+		"\xfa",
+		u8"😸",
+	};
+	bool pass = true;
+
+	for (unsigned i = 0; i < CYAML_ARRAY_LEN(strings); i++) {
+		ttest_ctx_t tc;
+		char name[sizeof(__func__) + 32];
+		sprintf(name, "%s_%u", __func__, i);
+
+		tc = ttest_start(report, name, NULL, NULL);
+
+		if (cyaml_utf8_casecmp(strings[i], strings[i]) != 0) {
+			pass &= ttest_fail(&tc, "Failed to match: %s",
+					strings[i]);
+			continue;
+		}
+
+		pass &= ttest_pass(&tc);
+	}
+
+	return pass;
+}
+
+/**
+ * Test comparing strings that match.
+ *
+ * \param[in]  report  The test report context.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_utf8_strcmp_matches(
+		ttest_report_ctx_t *report)
+{
+	struct string_pairs {
+		const char *a;
+		const char *b;
+	} pairs[] = {
+		{ "", "" },
+		{ "This is a TEST", "this is A test" },
+		{ u8"ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ", u8"àáâãäåæçèéêëìíîïðñòóôõö" },
+		{ u8"ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞ", u8"āăąćĉċčďđēĕėęěĝğ" },
+		{ u8"ĳĵķĸĺļľ", u8"ĲĴĶĸĹĻĽ" },
+		{ u8"ŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶ", u8"ŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷ" },
+		{ u8"űųŵŷŸźżž", u8"űųŵŷÿŹŻŽ" },
+		{ u8"ƂƄ ơƣƥ", u8"ƃƅ ƠƢƤ" },
+		{ u8"ǞǠǢǤǦǨǪǬǮ", u8"ǟǡǣǥǧǩǫǭǯ" },
+		{ u8"ǸǺǼǾȀȂȄȆȈȊȌȎȐȒȔȖȘȚȜȞ", u8"ǹǻǽǿȁȃȅȇȉȋȍȏȑȓȕȗșțȝȟ" },
+		{ u8"ȢȤȦȨȪȬȮȰȲ", u8"ȣȥȧȩȫȭȯȱȳ" },
+		{ u8"ɇɉɋɍɏ", u8"ɆɈɊɌɎ" },
+		{ u8"ƯźżžƳƵ", u8"ưŹŻŽƴƶ" },
+		{ u8"ǍǏǑǓǕǗǙǛ", u8"ǎǐǒǔǖǘǚǜ" },
+		{ u8"\u0178", u8"\u00ff" },
+		{ u8"\u0187", u8"\u0188" },
+		{ u8"\u018b", u8"\u018c" },
+		{ u8"\u018e", u8"\u01dd" },
+		{ u8"\u0191", u8"\u0192" },
+		{ u8"\u0198", u8"\u0199" },
+		{ u8"\u01a7", u8"\u01a8" },
+		{ u8"\u01ac", u8"\u01ad" },
+		{ u8"\u01af", u8"\u01b0" },
+		{ u8"\u01b7", u8"\u0292" },
+		{ u8"\u01b8", u8"\u01b9" },
+		{ u8"\u01bc", u8"\u01bd" },
+		{ u8"\u01c4", u8"\u01c6" },
+		{ u8"\u01c5", u8"\u01c6" },
+		{ u8"\u01c7", u8"\u01c9" },
+		{ u8"\u01c8", u8"\u01c9" },
+		{ u8"\u01ca", u8"\u01cc" },
+		{ u8"\u01cb", u8"\u01cc" },
+		{ u8"\u01f1", u8"\u01f3" },
+		{ u8"\u01f2", u8"\u01f3" },
+		{ u8"\u01f4", u8"\u01f5" },
+		{ u8"\u01f7", u8"\u01bf" },
+		{ u8"\u0220", u8"\u019e" },
+		{ u8"\u023b", u8"\u023c" },
+		{ u8"\u023d", u8"\u019a" },
+		{ u8"\u0241", u8"\u0242" },
+		{ u8"\u0243", u8"\u0180" },
+		{ "\xF0\x9F\x98\xB8", "\xF0\x9F\x98\xB8" },
+		{ "\xF0\x00\x98\xB8", "\xF0\x00\x98\xB8" },
+		{ "\xF0\x9F\x00\xB8", "\xF0\x9F\x00\xB8" },
+		{ "\xF0\x9F\x98\x00", "\xF0\x9F\x98\x00" },
+		{ "\xE2\x9F\x9A", "\xE2\x9F\x9A" },
+		{ "\xE2\x00\x9A", "\xE2\x00\x9A" },
+		{ "\xE2\x9F\x00", "\xE2\x9F\x00" },
+	};
+	bool pass = true;
+
+	for (unsigned i = 0; i < CYAML_ARRAY_LEN(pairs); i++) {
+		ttest_ctx_t tc;
+		char name[sizeof(__func__) + 32];
+		sprintf(name, "%s_%u", __func__, i);
+
+		tc = ttest_start(report, name, NULL, NULL);
+
+		if (cyaml_utf8_casecmp(pairs[i].a, pairs[i].b) != 0) {
+			pass &= ttest_fail(&tc, "Failed to match strings: "
+					"%s and %s", pairs[i].a, pairs[i].b);
+			continue;
+		}
+
+		pass &= ttest_pass(&tc);
+	}
+
+	return pass;
+}
+
+/**
+ * Test comparing strings that match.
+ *
+ * \param[in]  report  The test report context.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_utf8_strcmp_mismatches(
+		ttest_report_ctx_t *report)
+{
+	struct string_pairs {
+		const char *a;
+		const char *b;
+	} pairs[] = {
+		{ "Invalid", "\xfa" },
+		{ "Cat", u8"😸" },
+		{ "cat", u8"😸" },
+		{ "1 cat", u8"😸" },
+		{ "[cat]", u8"😸" },
+		{ "Ü cat", u8"😸" },
+	};
+	bool pass = true;
+
+	for (unsigned i = 0; i < CYAML_ARRAY_LEN(pairs); i++) {
+		ttest_ctx_t tc;
+		char name[sizeof(__func__) + 32];
+		sprintf(name, "%s_%u", __func__, i);
+
+		tc = ttest_start(report, name, NULL, NULL);
+
+		if (cyaml_utf8_casecmp(pairs[i].a, pairs[i].b) == 0) {
+			pass &= ttest_fail(&tc, "Failed to detect mismatch: "
+					"%s and %s", pairs[i].a, pairs[i].b);
+			continue;
+		}
+
+		pass &= ttest_pass(&tc);
+	}
+
+	return pass;
+}
+
+/**
+ * Run the CYAML util unit tests.
+ *
+ * \param[in]  rc         The ttest report context.
+ * \param[in]  log_level  CYAML log level.
+ * \param[in]  log_fn     CYAML logging function, or NULL.
+ * \return true iff all unit tests pass, otherwise false.
+ */
+bool utf8_tests(
+		ttest_report_ctx_t *rc,
+		cyaml_log_t log_level,
+		cyaml_log_fn_t log_fn)
+{
+	bool pass = true;
+
+	UNUSED(log_level);
+	UNUSED(log_fn);
+
+	ttest_heading(rc, "UTF-8 tests: String comparison");
+
+	pass &= test_utf8_strcmp_same(rc);
+	pass &= test_utf8_strcmp_matches(rc);
+	pass &= test_utf8_strcmp_mismatches(rc);
+
+	return pass;
+}


### PR DESCRIPTION
Enable mapping field names, enumeration values, and flags values to use caseless string comparison.