### PR TITLE
Address and Undefined Behaviour Santitizers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ VERSION_FLAGS = -DVERSION_MAJOR=$(VERSION_MAJOR) \
 INCLUDE = -I include
 CFLAGS += $(INCLUDE) $(VERSION_FLAGS)
 CFLAGS += -std=c11 -Wall -Wextra -pedantic
-LDFLAGS = -lyaml
+LDFLAGS += -lyaml
 
 ifeq ($(VARIANT), debug)
 	CFLAGS += -O0 -g

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,14 @@
 #
 # Copyright (C) 2017-2018 Michael Drake <tlsa@netsurf-browser.org>
 
+# Unfortunately ASan is incompatible with valgrind, so we have a special
+# variant for running with sanitisers.
 VARIANT = debug
-VALID_VARIANTS := release debug
+VALID_VARIANTS := release debug san
 
 ifneq ($(filter $(VARIANT),$(VALID_VARIANTS)),)
 else
-$(error VARIANT must be 'debug' (default) or 'release')
+$(error VARIANT must be 'debug' (default), 'san', or 'release')
 endif
 
 # CYAML's versioning is <MAJOR>.<MINOR>.<PATCH>[-DEVEL]
@@ -43,6 +45,9 @@ LDFLAGS += -lyaml
 
 ifeq ($(VARIANT), debug)
 	CFLAGS += -O0 -g
+else ifeq ($(VARIANT), san)
+	CFLAGS += -O0 -g -fsanitize=address -fsanitize=undefined
+	LDFLAGS += -fsanitize=address -fsanitize=undefined
 else
 	CFLAGS += -O2 -DNDEBUG
 endif

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ To build the library (debug mode), run:
 
     make
 
+Another debug build variant which is built with address sanitiser (incompatible
+with valgrind) can be built with:
+
+    make VARIANT=san
+
 To build a release version:
 
     make VARIANT=release
@@ -58,13 +63,14 @@ To install a release version of the library, run:
     make install VARIANT=release
 
 It will install to the PREFIX `/usr/local` by default, and it will use
-DESTDIR and PREFIX from the environement if set.
+DESTDIR and PREFIX from the environment if set.
 
 Testing
 -------
 
 To run the tests, run any of the following, which generate various
-levels of output verbosity (optionally setting `VARIANT=release`):
+levels of output verbosity (optionally setting `VARIANT=release`, or
+`VARIANT=san`):
 
     make test
     make test-quiet


### PR DESCRIPTION
Adds `VARIANT=san`, which can be used to run the tests with asan and ubsan.