### PR TITLE
Tlsa/ptr macro variants

### DIFF
--- a/include/cyaml/cyaml.h
+++ b/include/cyaml/cyaml.h
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: ISC
  *
- * Copyright (c) 2017-2018 Michael Drake <tlsa@netsurf-browser.org>
+ * Copyright (c) 2017-2019 Michael Drake <tlsa@netsurf-browser.org>
  */
 
 /**
@@ -475,6 +475,8 @@ typedef enum cyaml_err {
 /**
  * Mapping schema helper macro for keys with \ref CYAML_INT type.
  *
+ * Use this for integers contained in structs.
+ *
  * \param[in]  _key        String defining the YAML mapping key for this value.
  * \param[in]  _flags      Any behavioural flags relevant to this value.
  * \param[in]  _structure  The structure corresponding to the mapping.
@@ -485,7 +487,29 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.value = { \
-		CYAML_VALUE_INT((_flags), ((_structure *)NULL)->_member), \
+		CYAML_VALUE_INT(((_flags) & (~CYAML_FLAG_POINTER)), \
+				(((_structure *)NULL)->_member)), \
+	}, \
+	.data_offset = offsetof(_structure, _member) \
+}
+
+/**
+ * Mapping schema helper macro for keys with \ref CYAML_INT type.
+ *
+ * Use this for pointers to integers.
+ *
+ * \param[in]  _key        String defining the YAML mapping key for this value.
+ * \param[in]  _flags      Any behavioural flags relevant to this value.
+ * \param[in]  _structure  The structure corresponding to the mapping.
+ * \param[in]  _member     The member in _structure for this mapping value.
+ */
+#define CYAML_FIELD_INT_PTR( \
+		_key, _flags, _structure, _member) \
+{ \
+	.key = _key, \
+	.value = { \
+		CYAML_VALUE_INT(((_flags) | CYAML_FLAG_POINTER), \
+				(*(((_structure *)NULL)->_member))), \
 	}, \
 	.data_offset = offsetof(_structure, _member) \
 }
@@ -505,6 +529,8 @@ typedef enum cyaml_err {
 /**
  * Mapping schema helper macro for keys with \ref CYAML_UINT type.
  *
+ * Use this for unsigned integers contained in structs.
+ *
  * \param[in]  _key        String defining the YAML mapping key for this value.
  * \param[in]  _flags      Any behavioural flags relevant to this value.
  * \param[in]  _structure  The structure corresponding to the mapping.
@@ -515,7 +541,29 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.value = { \
-		CYAML_VALUE_UINT((_flags), ((_structure *)NULL)->_member), \
+		CYAML_VALUE_UINT(((_flags) & (~CYAML_FLAG_POINTER)), \
+				(((_structure *)NULL)->_member)), \
+	}, \
+	.data_offset = offsetof(_structure, _member) \
+}
+
+/**
+ * Mapping schema helper macro for keys with \ref CYAML_UINT type.
+ *
+ * Use this for pointers to unsigned integers.
+ *
+ * \param[in]  _key        String defining the YAML mapping key for this value.
+ * \param[in]  _flags      Any behavioural flags relevant to this value.
+ * \param[in]  _structure  The structure corresponding to the mapping.
+ * \param[in]  _member     The member in _structure for this mapping value.
+ */
+#define CYAML_FIELD_UINT_PTR( \
+		_key, _flags, _structure, _member) \
+{ \
+	.key = _key, \
+	.value = { \
+		CYAML_VALUE_UINT(((_flags) | CYAML_FLAG_POINTER), \
+				(*(((_structure *)NULL)->_member))), \
 	}, \
 	.data_offset = offsetof(_structure, _member) \
 }
@@ -535,6 +583,8 @@ typedef enum cyaml_err {
 /**
  * Mapping schema helper macro for keys with \ref CYAML_BOOL type.
  *
+ * Use this for boolean types contained in structs.
+ *
  * \param[in]  _key        String defining the YAML mapping key for this value.
  * \param[in]  _flags      Any behavioural flags relevant to this value.
  * \param[in]  _structure  The structure corresponding to the mapping.
@@ -545,7 +595,29 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.value = { \
-		CYAML_VALUE_BOOL((_flags), ((_structure *)NULL)->_member), \
+		CYAML_VALUE_BOOL(((_flags) & (~CYAML_FLAG_POINTER)), \
+				(((_structure *)NULL)->_member)), \
+	}, \
+	.data_offset = offsetof(_structure, _member) \
+}
+
+/**
+ * Mapping schema helper macro for keys with \ref CYAML_BOOL type.
+ *
+ * Use this for pointers to boolean types.
+ *
+ * \param[in]  _key        String defining the YAML mapping key for this value.
+ * \param[in]  _flags      Any behavioural flags relevant to this value.
+ * \param[in]  _structure  The structure corresponding to the mapping.
+ * \param[in]  _member     The member in _structure for this mapping value.
+ */
+#define CYAML_FIELD_BOOL_PTR( \
+		_key, _flags, _structure, _member) \
+{ \
+	.key = _key, \
+	.value = { \
+		CYAML_VALUE_BOOL(((_flags) | CYAML_FLAG_POINTER), \
+				(*(((_structure *)NULL)->_member))), \
 	}, \
 	.data_offset = offsetof(_structure, _member) \
 }
@@ -571,6 +643,8 @@ typedef enum cyaml_err {
 /**
  * Mapping schema helper macro for keys with \ref CYAML_ENUM type.
  *
+ * Use this for enumerated types contained in structs.
+ *
  * \param[in]  _key        String defining the YAML mapping key for this value.
  * \param[in]  _flags      Any behavioural flags relevant to this value.
  * \param[in]  _structure  The structure corresponding to the mapping.
@@ -583,7 +657,32 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.value = { \
-		CYAML_VALUE_ENUM((_flags), ((_structure *)NULL)->_member, \
+		CYAML_VALUE_ENUM(((_flags) & (~CYAML_FLAG_POINTER)), \
+				(((_structure *)NULL)->_member), \
+				_strings, _strings_count), \
+	}, \
+	.data_offset = offsetof(_structure, _member) \
+}
+
+/**
+ * Mapping schema helper macro for keys with \ref CYAML_ENUM type.
+ *
+ * Use this for pointers to enumerated types.
+ *
+ * \param[in]  _key        String defining the YAML mapping key for this value.
+ * \param[in]  _flags      Any behavioural flags relevant to this value.
+ * \param[in]  _structure  The structure corresponding to the mapping.
+ * \param[in]  _member     The member in _structure for this mapping value.
+ * \param[in]  _strings       Array of string data for enumeration values.
+ * \param[in]  _strings_count Number of entries in _strings.
+ */
+#define CYAML_FIELD_ENUM_PTR( \
+		_key, _flags, _structure, _member, _strings, _strings_count) \
+{ \
+	.key = _key, \
+	.value = { \
+		CYAML_VALUE_ENUM(((_flags) | CYAML_FLAG_POINTER), \
+				(*(((_structure *)NULL)->_member)), \
 				_strings, _strings_count), \
 	}, \
 	.data_offset = offsetof(_structure, _member) \
@@ -610,6 +709,8 @@ typedef enum cyaml_err {
 /**
  * Mapping schema helper macro for keys with \ref CYAML_FLAGS type.
  *
+ * Use this for flag types contained in structs.
+ *
  * \param[in]  _key        String defining the YAML mapping key for this value.
  * \param[in]  _flags      Any behavioural flags relevant to this value.
  * \param[in]  _structure  The structure corresponding to the mapping.
@@ -622,7 +723,32 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.value = { \
-		CYAML_VALUE_FLAGS((_flags), ((_structure *)NULL)->_member, \
+		CYAML_VALUE_FLAGS(((_flags) & (~CYAML_FLAG_POINTER)), \
+				(((_structure *)NULL)->_member), \
+				_strings, _strings_count), \
+	}, \
+	.data_offset = offsetof(_structure, _member) \
+}
+
+/**
+ * Mapping schema helper macro for keys with \ref CYAML_FLAGS type.
+ *
+ * Use this for pointers to flag types.
+ *
+ * \param[in]  _key        String defining the YAML mapping key for this value.
+ * \param[in]  _flags      Any behavioural flags relevant to this value.
+ * \param[in]  _structure  The structure corresponding to the mapping.
+ * \param[in]  _member     The member in _structure for this mapping value.
+ * \param[in]  _strings       Array of string data for flag values.
+ * \param[in]  _strings_count Number of entries in _strings.
+ */
+#define CYAML_FIELD_FLAGS_PTR( \
+		_key, _flags, _structure, _member, _strings, _strings_count) \
+{ \
+	.key = _key, \
+	.value = { \
+		CYAML_VALUE_FLAGS(((_flags) | CYAML_FLAG_POINTER), \
+				(*(((_structure *)NULL)->_member)), \
 				_strings, _strings_count), \
 	}, \
 	.data_offset = offsetof(_structure, _member) \
@@ -643,6 +769,8 @@ typedef enum cyaml_err {
 /**
  * Mapping schema helper macro for keys with \ref CYAML_FLOAT type.
  *
+ * Use this for floating point types contained in structs.
+ *
  * \param[in]  _key        String defining the YAML mapping key for this value.
  * \param[in]  _flags      Any behavioural flags relevant to this value.
  * \param[in]  _structure  The structure corresponding to the mapping.
@@ -653,7 +781,29 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.value = { \
-		CYAML_VALUE_FLOAT((_flags), ((_structure *)NULL)->_member), \
+		CYAML_VALUE_FLOAT(((_flags) & (~CYAML_FLAG_POINTER)), \
+				(((_structure *)NULL)->_member)), \
+	}, \
+	.data_offset = offsetof(_structure, _member) \
+}
+
+/**
+ * Mapping schema helper macro for keys with \ref CYAML_FLOAT type.
+ *
+ * Use this for pointers to floating point types.
+ *
+ * \param[in]  _key        String defining the YAML mapping key for this value.
+ * \param[in]  _flags      Any behavioural flags relevant to this value.
+ * \param[in]  _structure  The structure corresponding to the mapping.
+ * \param[in]  _member     The member in _structure for this mapping value.
+ */
+#define CYAML_FIELD_FLOAT_PTR( \
+		_key, _flags, _structure, _member) \
+{ \
+	.key = _key, \
+	.value = { \
+		CYAML_VALUE_FLOAT(((_flags) | CYAML_FLAG_POINTER), \
+				(*(((_structure *)NULL)->_member))), \
 	}, \
 	.data_offset = offsetof(_structure, _member) \
 }

--- a/test/units/load.c
+++ b/test/units/load.c
@@ -1182,6 +1182,77 @@ static bool test_load_mapping_entry_flags(
 }
 
 /**
+ * Test loading a pointer to a flag word.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_mapping_entry_flags_ptr(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	enum test_flags {
+		TEST_FLAGS_NONE   = 0,
+		TEST_FLAGS_FIRST  = (1 << 0),
+		TEST_FLAGS_SECOND = (1 << 1),
+		TEST_FLAGS_THIRD  = (1 << 2),
+		TEST_FLAGS_FOURTH = (1 << 3),
+		TEST_FLAGS_FIFTH  = (1 << 4),
+		TEST_FLAGS_SIXTH  = (1 << 5),
+	} value = TEST_FLAGS_SECOND | TEST_FLAGS_FIFTH | 1024;
+	static const cyaml_strval_t strings[] = {
+		{ "none",   TEST_FLAGS_NONE },
+		{ "first",  TEST_FLAGS_FIRST },
+		{ "second", TEST_FLAGS_SECOND },
+		{ "third",  TEST_FLAGS_THIRD },
+		{ "fourth", TEST_FLAGS_FOURTH },
+		{ "fifth",  TEST_FLAGS_FIFTH },
+		{ "sixth",  TEST_FLAGS_SIXTH },
+	};
+	static const unsigned char yaml[] =
+		"test_flags:\n"
+		"    - second\n"
+		"    - fifth\n"
+		"    - 1024\n";
+	struct target_struct {
+		enum test_flags *test_value_flags;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD_FLAGS_PTR("test_flags", CYAML_FLAG_POINTER,
+				struct target_struct, test_value_flags,
+				strings, CYAML_ARRAY_LEN(strings)),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (*data_tgt->test_value_flags != value) {
+		return ttest_fail(&tc, "Incorrect value: "
+				"expected: 0x%x, got: 0x%x\n",
+				value, data_tgt->test_value_flags);
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
  * Test loading an empty flag word.
  *
  * \param[in]  report  The test report context.
@@ -5200,6 +5271,7 @@ bool load_tests(
 
 	pass &= test_load_mapping_entry_flags(rc, &config);
 	pass &= test_load_mapping_entry_mapping(rc, &config);
+	pass &= test_load_mapping_entry_flags_ptr(rc, &config);
 	pass &= test_load_mapping_entry_mapping_ptr(rc, &config);
 	pass &= test_load_mapping_entry_flags_empty(rc, &config);
 	pass &= test_load_mapping_entry_flags_sparse(rc, &config);

--- a/test/units/load.c
+++ b/test/units/load.c
@@ -290,6 +290,54 @@ static bool test_load_mapping_entry_uint(
 }
 
 /**
+ * Test loading a pointer to an unsigned integer.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_mapping_entry_uint_ptr(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	unsigned value = 9999;
+	static const unsigned char yaml[] =
+		"test_uint: 9999\n";
+	struct target_struct {
+		unsigned *test_value_uint;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD_UINT_PTR("test_uint", CYAML_FLAG_POINTER,
+				struct target_struct, test_value_uint),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (*data_tgt->test_value_uint != value) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
  * Test loading a floating point value as a float.
  *
  * \param[in]  report  The test report context.
@@ -4878,6 +4926,7 @@ bool load_tests(
 	pass &= test_load_mapping_entry_string(rc, &config);
 	pass &= test_load_mapping_entry_int_pos(rc, &config);
 	pass &= test_load_mapping_entry_int_neg(rc, &config);
+	pass &= test_load_mapping_entry_uint_ptr(rc, &config);
 	pass &= test_load_mapping_entry_bool_true(rc, &config);
 	pass &= test_load_mapping_entry_bool_false(rc, &config);
 	pass &= test_load_mapping_entry_string_ptr(rc, &config);

--- a/test/units/load.c
+++ b/test/units/load.c
@@ -634,6 +634,102 @@ static bool test_load_mapping_entry_bool_false(
 }
 
 /**
+ * Test loading a pointer to a boolean value (true).
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_mapping_entry_bool_true_ptr(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	bool value = true;
+	static const unsigned char yaml[] =
+		"test_bool: true\n";
+	struct target_struct {
+		unsigned *test_value_bool;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD_BOOL_PTR("test_bool", CYAML_FLAG_POINTER,
+				struct target_struct, test_value_bool),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (*data_tgt->test_value_bool != value) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading a pointer to a boolean value (false).
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_mapping_entry_bool_false_ptr(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	bool value = false;
+	static const unsigned char yaml[] =
+		"test_bool: false\n";
+	struct target_struct {
+		unsigned *test_value_bool;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD_BOOL_PTR("test_bool", CYAML_FLAG_POINTER,
+				struct target_struct, test_value_bool),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (*data_tgt->test_value_bool != value) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
  * Test loading an enumeration.
  *
  * \param[in]  report  The test report context.
@@ -5037,6 +5133,8 @@ bool load_tests(
 	pass &= test_load_mapping_entry_enum_sparse(rc, &config);
 	pass &= test_load_mapping_entry_ignore_deep(rc, &config);
 	pass &= test_load_mapping_entry_ignore_scalar(rc, &config);
+	pass &= test_load_mapping_entry_bool_true_ptr(rc, &config);
+	pass &= test_load_mapping_entry_bool_false_ptr(rc, &config);
 
 	ttest_heading(rc, "Load single entry mapping tests: complex types");
 

--- a/test/units/load.c
+++ b/test/units/load.c
@@ -388,6 +388,56 @@ static bool test_load_mapping_entry_float(
 }
 
 /**
+ * Test loading a floating point value as a pointer to float.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_mapping_entry_float_ptr(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	float value = 3.14159;
+	static const unsigned char yaml[] =
+		"test_fp: 3.14159\n";
+	struct target_struct {
+		float *test_value_fp;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD_FLOAT_PTR("test_fp", CYAML_FLAG_POINTER,
+				struct target_struct, test_value_fp),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (*data_tgt->test_value_fp != value) {
+		return ttest_fail(&tc, "Incorrect value: "
+				"expected: %lf, got: %lf",
+				value, data_tgt->test_value_fp);
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
  * Test loading a floating point value as a double.
  *
  * \param[in]  report  The test report context.
@@ -429,6 +479,56 @@ static bool test_load_mapping_entry_double(
 	}
 
 	if (data_tgt->test_value_fp != value) {
+		return ttest_fail(&tc, "Incorrect value: "
+				"expected: %lf, got: %lf",
+				value, data_tgt->test_value_fp);
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading a floating point value as a pointer to double.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_mapping_entry_double_ptr(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	double value = 3.14159;
+	static const unsigned char yaml[] =
+		"test_fp: 3.14159\n";
+	struct target_struct {
+		double *test_value_fp;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD_FLOAT_PTR("test_fp", CYAML_FLAG_POINTER,
+				struct target_struct, test_value_fp),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (*data_tgt->test_value_fp != value) {
 		return ttest_fail(&tc, "Incorrect value: "
 				"expected: %lf, got: %lf",
 				value, data_tgt->test_value_fp);
@@ -4927,8 +5027,10 @@ bool load_tests(
 	pass &= test_load_mapping_entry_int_pos(rc, &config);
 	pass &= test_load_mapping_entry_int_neg(rc, &config);
 	pass &= test_load_mapping_entry_uint_ptr(rc, &config);
+	pass &= test_load_mapping_entry_float_ptr(rc, &config);
 	pass &= test_load_mapping_entry_bool_true(rc, &config);
 	pass &= test_load_mapping_entry_bool_false(rc, &config);
+	pass &= test_load_mapping_entry_double_ptr(rc, &config);
 	pass &= test_load_mapping_entry_string_ptr(rc, &config);
 	pass &= test_load_mapping_entry_int_pos_ptr(rc, &config);
 	pass &= test_load_mapping_entry_int_neg_ptr(rc, &config);

--- a/test/units/load.c
+++ b/test/units/load.c
@@ -789,6 +789,65 @@ static bool test_load_mapping_entry_enum(
 }
 
 /**
+ * Test loading a pointer to an enumeration.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_mapping_entry_enum_ptr(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	enum test_enum {
+		TEST_ENUM_FIRST,
+		TEST_ENUM_SECOND,
+		TEST_ENUM_THIRD,
+		TEST_ENUM__COUNT,
+	} value = TEST_ENUM_SECOND;
+	static const cyaml_strval_t strings[TEST_ENUM__COUNT] = {
+		[TEST_ENUM_FIRST]  = { "first",  0 },
+		[TEST_ENUM_SECOND] = { "second", 1 },
+		[TEST_ENUM_THIRD]  = { "third",  2 },
+	};
+	static const unsigned char yaml[] =
+		"test_enum: second\n";
+	struct target_struct {
+		enum test_enum *test_value_enum;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD_ENUM_PTR("test_enum", CYAML_FLAG_POINTER,
+				struct target_struct, test_value_enum,
+				strings, TEST_ENUM__COUNT),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (*data_tgt->test_value_enum != value) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
  * Test loading a sparse enumeration.
  *
  * \param[in]  report  The test report context.
@@ -5122,6 +5181,7 @@ bool load_tests(
 	pass &= test_load_mapping_entry_string(rc, &config);
 	pass &= test_load_mapping_entry_int_pos(rc, &config);
 	pass &= test_load_mapping_entry_int_neg(rc, &config);
+	pass &= test_load_mapping_entry_enum_ptr(rc, &config);
 	pass &= test_load_mapping_entry_uint_ptr(rc, &config);
 	pass &= test_load_mapping_entry_float_ptr(rc, &config);
 	pass &= test_load_mapping_entry_bool_true(rc, &config);

--- a/test/units/load.c
+++ b/test/units/load.c
@@ -146,6 +146,102 @@ static bool test_load_mapping_entry_int_neg(
 }
 
 /**
+ * Test loading a pointer to a positive signed integer.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_mapping_entry_int_pos_ptr(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	int value = 90;
+	static const unsigned char yaml[] =
+		"test_int: 90\n";
+	struct target_struct {
+		int *test_value_int;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD_INT_PTR("test_int", CYAML_FLAG_POINTER,
+				struct target_struct, test_value_int),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (*data_tgt->test_value_int != value) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading a pointer to a  negative signed integer.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_mapping_entry_int_neg_ptr(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	int value = -77;
+	static const unsigned char yaml[] =
+		"test_int: -77\n";
+	struct target_struct {
+		int *test_value_int;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD_INT_PTR("test_int", CYAML_FLAG_POINTER,
+				struct target_struct, test_value_int),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (*data_tgt->test_value_int != value) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
  * Test loading an unsigned integer.
  *
  * \param[in]  report  The test report context.
@@ -4785,6 +4881,8 @@ bool load_tests(
 	pass &= test_load_mapping_entry_bool_true(rc, &config);
 	pass &= test_load_mapping_entry_bool_false(rc, &config);
 	pass &= test_load_mapping_entry_string_ptr(rc, &config);
+	pass &= test_load_mapping_entry_int_pos_ptr(rc, &config);
+	pass &= test_load_mapping_entry_int_neg_ptr(rc, &config);
 	pass &= test_load_mapping_entry_enum_sparse(rc, &config);
 	pass &= test_load_mapping_entry_ignore_deep(rc, &config);
 	pass &= test_load_mapping_entry_ignore_scalar(rc, &config);


### PR DESCRIPTION
Add mapping field schema building helper macros for primitive types.

Implements #67.