### PR TITLE
Skip writing OPTIONAL | POINTER value when pointer value is NULL

### DIFF
--- a/src/save.c
+++ b/src/save.c
@@ -1017,6 +1017,17 @@ static cyaml_err_t cyaml__write_mapping(
 			return CYAML_OK;
 		}
 
+		if ((field->value.flags & CYAML_FLAG_OPTIONAL) == CYAML_FLAG_OPTIONAL) {
+			if ((field->value.flags & CYAML_FLAG_POINTER) == CYAML_FLAG_POINTER) {
+				const void **p = (const void **)(ctx->state->data + field->data_offset);
+				if (*p == NULL) {
+					// Skip NULL pointer value if OPTIONAL:
+					ctx->state->mapping.field++;
+					return CYAML_OK;
+				}
+			}
+		}
+
 		err = cyaml__emit_scalar(ctx, NULL, field->key,
 				YAML_STR_TAG);
 		if (err != CYAML_OK) {


### PR DESCRIPTION
I know this is totally trivial but, somewhat amazingly, this tiny patch got me past my roadblock in my project. Hope it helps to seed your implementation of OPTIONAL serialization.

This PR fixes issue #70 for my use case.