### PR TITLE
Use static assertion to clean up pointer handling code

### DIFF
--- a/src/data.h
+++ b/src/data.h
@@ -108,4 +108,26 @@ static inline uint64_t cyaml_data_read(
 	return ret;
 }
 
+/**
+ * Read a pointer from data.
+ *
+ * This is a wrapper for \ref cyaml_data_read that does a compile time
+ * assertion on the pointer size, so it can never return a runtime error.
+ *
+ * \param[in]  data        The address to read from.
+ * \return Returns the value read from data.
+ */
+static inline uint8_t * cyaml_data_read_pointer(
+		const uint8_t *data)
+{
+	cyaml_err_t err;
+
+	/* Refuse to build on platforms where sizeof pointer would
+	 * lead to \ref CYAML_ERR_INVALID_DATA_SIZE. */
+	cyaml_static_assert(sizeof(char *) >  0);
+	cyaml_static_assert(sizeof(char *) <= sizeof(uint64_t));
+
+	return (void *)cyaml_data_read(sizeof(char *), data, &err);
+}
+
 #endif

--- a/src/data.h
+++ b/src/data.h
@@ -13,6 +13,7 @@
 #define CYAML_DATA_H
 
 #include "cyaml/cyaml.h"
+#include "util.h"
 
 /**
  * Write a value of up to eight bytes to data_target.
@@ -44,6 +45,29 @@ static inline cyaml_err_t cyaml_data_write(
 	}
 
 	return CYAML_OK;
+}
+
+/**
+ * Write a pointer to data.
+ *
+ * This is a wrapper for \ref cyaml_data_write that does a compile time
+ * assertion on the pointer size, so it can never return a runtime error.
+ *
+ * \param[in]  ptr         The pointer address to write.
+ * \param[in]  data        The address to write to.
+ */
+static inline void cyaml_data_write_pointer(
+		const void *ptr,
+		uint8_t *data_target)
+{
+	/* Refuse to build on platforms where sizeof pointer would
+	 * lead to \ref CYAML_ERR_INVALID_DATA_SIZE. */
+	cyaml_static_assert(sizeof(char *) >  0);
+	cyaml_static_assert(sizeof(char *) <= sizeof(uint64_t));
+
+	CYAML_UNUSED(cyaml_data_write((uint64_t)ptr, sizeof(ptr), data_target));
+
+	return;
 }
 
 /**

--- a/src/free.c
+++ b/src/free.c
@@ -112,9 +112,8 @@ static void cyaml__free_value(
 		unsigned count)
 {
 	if (schema->flags & CYAML_FLAG_POINTER) {
-		cyaml_err_t err;
-		data = (void *)cyaml_data_read(sizeof(char *), data, &err);
-		if ((err != CYAML_OK) || (data == NULL)) {
+		data = cyaml_data_read_pointer(data);
+		if (data == NULL) {
 			return;
 		}
 	}

--- a/src/load.c
+++ b/src/load.c
@@ -501,7 +501,6 @@ static cyaml_err_t cyaml__data_handle_pointer(
 		const yaml_event_t *event,
 		uint8_t **value_data_io)
 {
-	cyaml_err_t err = CYAML_OK;
 	cyaml_state_t *state = ctx->state;
 
 	if (schema->flags & CYAML_FLAG_POINTER) {
@@ -548,18 +547,14 @@ static cyaml_err_t cyaml__data_handle_pointer(
 		}
 
 		/* Write the allocation pointer into the data structure. */
-		err = cyaml_data_write((uint64_t)value_data,
-				sizeof(value_data), *value_data_io);
-		if (err != CYAML_OK) {
-			return err;
-		}
+		cyaml_data_write_pointer(value_data, *value_data_io);
 
 		/* Update the caller's pointer so it can write the value to
 		 * the right place. */
 		*value_data_io = value_data;
 	}
 
-	return err;
+	return CYAML_OK;
 }
 
 /**

--- a/src/util.h
+++ b/src/util.h
@@ -15,6 +15,14 @@
 #include "cyaml/cyaml.h"
 #include "utf8.h"
 
+/** Compile time assertion macro. */
+#define cyaml_static_assert(e) \
+{ \
+	enum { \
+		cyaml_static_assert_check = 1 / (!!(e)) \
+	}; \
+}
+
 /** Macro to squash unused variable compiler warnings. */
 #define CYAML_UNUSED(_x) ((void)(_x))
 


### PR DESCRIPTION
This is a slight code cleanup which mostly improves readability.
It gets rid of handling of errors that couldn't happen.