### PR TITLE
Add support for aliases and anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 LibCYAML: Schema-based YAML parsing and serialisation
 =====================================================
 
-[![Build Status](https://travis-ci.org/tlsa/libcyaml.svg?branch=master)](https://travis-ci.org/tlsa/libcyaml) [![Code Coverage](https://codecov.io/gh/tlsa/libcyaml/branch/master/graph/badge.svg)](https://codecov.io/gh/tlsa/libcyaml) [![Total alerts](https://img.shields.io/lgtm/alerts/g/tlsa/libcyaml.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/tlsa/libcyaml/alerts/) [![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/tlsa/libcyaml.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/tlsa/libcyaml/context:cpp)
+[![Build Status](https://travis-ci.org/tlsa/libcyaml.svg?branch=master)](https://travis-ci.org/tlsa/libcyaml) [![Code Coverage](https://codecov.io/gh/tlsa/libcyaml/branch/master/graph/badge.svg)](https://codecov.io/gh/tlsa/libcyaml) [![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/tlsa/libcyaml.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/tlsa/libcyaml/alerts/)
 
 LibCYAML is a C library for reading and writing structured YAML documents.
 It is written in ISO C11 and licensed under the ISC licence.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ arranged in memory.
   conform to your schema.
 * Uses standard [`libyaml`](https://github.com/yaml/libyaml) library for
   low-level YAML read / write.
+* Support for YAML aliases and anchors.
 
 Status
 ------

--- a/include/cyaml/cyaml.h
+++ b/include/cyaml/cyaml.h
@@ -79,7 +79,7 @@ typedef enum cyaml_type {
 	CYAML_MAPPING,
 	/**
 	 * Value is a bit field.  Values of this type require an array of value
-	 * definititions in the schema entry.  If the bitfield is used to store
+	 * definitions in the schema entry.  If the bitfield is used to store
 	 * only single-bit flags, it may be better to use \ref CYAML_FLAGS
 	 * instead.
 	 *
@@ -306,7 +306,7 @@ typedef struct cyaml_schema_value {
 		} mapping;
 		/** \ref CYAML_BITFIELD type-specific schema data. */
 		struct {
-			/** Array of bit defintiions for the bitfield. */
+			/** Array of bit definitions for the bitfield. */
 			const struct cyaml_bitdef *bitdefs;
 			/** Entry count for bitdefs array. */
 			uint32_t count;
@@ -457,7 +457,7 @@ typedef enum cyaml_cfg_flags {
 /**
  * CYAML function return codes indicating success or reason for failure.
  *
- * Use \ref cyaml_strerror() to convert and error code to a human-readable
+ * Use \ref cyaml_strerror() to convert an error code to a human-readable
  * string.
  */
 typedef enum cyaml_err {

--- a/include/cyaml/cyaml.h
+++ b/include/cyaml/cyaml.h
@@ -479,6 +479,7 @@ typedef enum cyaml_err {
 	CYAML_ERR_FILE_OPEN,             /**< Failed to open file. */
 	CYAML_ERR_INVALID_KEY,           /**< Mapping key rejected by schema. */
 	CYAML_ERR_INVALID_VALUE,         /**< Value rejected by schema. */
+	CYAML_ERR_INVALID_ALIAS,         /**< No anchor found for alias. */
 	CYAML_ERR_INTERNAL_ERROR,        /**< Internal error in LibCYAML. */
 	CYAML_ERR_UNEXPECTED_EVENT,      /**< YAML event rejected by schema. */
 	CYAML_ERR_STRING_LENGTH_MIN,     /**< String length too short. */

--- a/include/cyaml/cyaml.h
+++ b/include/cyaml/cyaml.h
@@ -452,6 +452,18 @@ typedef enum cyaml_cfg_flags {
 	 * By default, strings are compared with case sensitivity.
 	 */
 	CYAML_CFG_CASE_INSENSITIVE    = (1 << 4),
+	/**
+	 * When loading, don't allow YAML aliases in the document.
+	 *
+	 * If this option is enabled, anchors will be ignored, and the
+	 * error code \ref CYAML_ERR_ALIAS will be returned if an alias
+	 * is encountered.
+	 *
+	 * Setting this removes the overhead of recording anchors, so
+	 * it may be worth setting if aliases are not required, and
+	 * memory is constrained.
+	 */
+	CYAML_CFG_NO_ALIAS            = (1 << 5),
 } cyaml_cfg_flags_t;
 
 /**
@@ -463,7 +475,7 @@ typedef enum cyaml_cfg_flags {
 typedef enum cyaml_err {
 	CYAML_OK,                        /**< Success. */
 	CYAML_ERR_OOM,                   /**< Memory allocation failed. */
-	CYAML_ERR_ALIAS,                 /**< YAML alias is unsupported. */
+	CYAML_ERR_ALIAS,                 /**< See \ref CYAML_CFG_NO_ALIAS. */
 	CYAML_ERR_FILE_OPEN,             /**< Failed to open file. */
 	CYAML_ERR_INVALID_KEY,           /**< Mapping key rejected by schema. */
 	CYAML_ERR_INVALID_VALUE,         /**< Value rejected by schema. */

--- a/src/load.c
+++ b/src/load.c
@@ -29,6 +29,24 @@
 #define CYAML_SCHEMA_IDX_NONE 0xffff
 
 /**
+ * CYAML events.  These correspond to `libyaml` events.
+ */
+typedef enum cyaml_event {
+	CYAML_EVT_NO_EVENT   = YAML_NO_EVENT,
+	CYAML_EVT_STRM_START = YAML_STREAM_START_EVENT,
+	CYAML_EVT_STRM_END   = YAML_STREAM_END_EVENT,
+	CYAML_EVT_DOC_START  = YAML_DOCUMENT_START_EVENT,
+	CYAML_EVT_DOC_END    = YAML_DOCUMENT_END_EVENT,
+	CYAML_EVT_ALIAS      = YAML_ALIAS_EVENT,
+	CYAML_EVT_SCALAR     = YAML_SCALAR_EVENT,
+	CYAML_EVT_SEQ_START  = YAML_SEQUENCE_START_EVENT,
+	CYAML_EVT_SEQ_END    = YAML_SEQUENCE_END_EVENT,
+	CYAML_EVT_MAP_START  = YAML_MAPPING_START_EVENT,
+	CYAML_EVT_MAP_END    = YAML_MAPPING_END_EVENT,
+	CYAML_EVT__COUNT,
+} cyaml_event_t;
+
+/**
  * A CYAML load state machine stack entry.
  */
 typedef struct cyaml_state {
@@ -89,24 +107,6 @@ typedef struct cyaml_ctx {
 	unsigned seq_count;     /**< Top-level sequence count. */
 	yaml_parser_t *parser;  /**< Internal libyaml parser object. */
 } cyaml_ctx_t;
-
-/**
- * CYAML events.  These correspond to `libyaml` events.
- */
-typedef enum cyaml_event {
-	CYAML_EVT_NO_EVENT   = YAML_NO_EVENT,
-	CYAML_EVT_STRM_START = YAML_STREAM_START_EVENT,
-	CYAML_EVT_STRM_END   = YAML_STREAM_END_EVENT,
-	CYAML_EVT_DOC_START  = YAML_DOCUMENT_START_EVENT,
-	CYAML_EVT_DOC_END    = YAML_DOCUMENT_END_EVENT,
-	CYAML_EVT_ALIAS      = YAML_ALIAS_EVENT,
-	CYAML_EVT_SCALAR     = YAML_SCALAR_EVENT,
-	CYAML_EVT_SEQ_START  = YAML_SEQUENCE_START_EVENT,
-	CYAML_EVT_SEQ_END    = YAML_SEQUENCE_END_EVENT,
-	CYAML_EVT_MAP_START  = YAML_MAPPING_START_EVENT,
-	CYAML_EVT_MAP_END    = YAML_MAPPING_END_EVENT,
-	CYAML_EVT__COUNT,
-} cyaml_event_t;
 
 /**
  * Get the CYAML event type from a `libyaml` event.

--- a/src/load.c
+++ b/src/load.c
@@ -150,8 +150,8 @@ static cyaml_err_t cyaml_get_next_event(
 		return CYAML_ERR_LIBYAML_PARSER;
 	}
 
-	if (event->type == YAML_ALIAS_EVENT) {
-		/** \todo Add support for alias? */
+	if (ctx->config->flags & CYAML_CFG_NO_ALIAS &&
+	    event->type == YAML_ALIAS_EVENT) {
 		yaml_event_delete(event);
 		return CYAML_ERR_ALIAS;
 	}

--- a/src/mem.h
+++ b/src/mem.h
@@ -79,4 +79,25 @@ static inline void * cyaml__alloc(
 	return cyaml__realloc(config, NULL, 0, size, clean);
 }
 
+/**
+ * Helper for string duplication using the client's choice of allocator routine.
+ *
+ * \param[in]  config  The CYAML client config.
+ * \param[in]  str     The string to duplicate.
+ * \return Pointer to new string on success, or `NULL` on failure.
+ */
+static inline char * cyaml__strdup(
+		const cyaml_config_t *config,
+		const char *str)
+{
+	size_t len = strlen(str) + 1;
+	char *dup = cyaml__alloc(config, len, false);
+	if (dup == NULL) {
+		return NULL;
+	}
+
+	memcpy(dup, str, len);
+	return dup;
+}
+
 #endif

--- a/src/util.c
+++ b/src/util.c
@@ -84,6 +84,7 @@ const char * cyaml_strerror(
 		[CYAML_ERR_FILE_OPEN]             = "Could not open file",
 		[CYAML_ERR_INVALID_KEY]           = "Invalid key",
 		[CYAML_ERR_INVALID_VALUE]         = "Invalid value",
+		[CYAML_ERR_INVALID_ALIAS]         = "No anchor found for alias",
 		[CYAML_ERR_INTERNAL_ERROR]        = "Internal error",
 		[CYAML_ERR_UNEXPECTED_EVENT]      = "Unexpected event",
 		[CYAML_ERR_STRING_LENGTH_MIN]     = "String length too short",

--- a/test/units/errs.c
+++ b/test/units/errs.c
@@ -5133,6 +5133,7 @@ static bool test_err_load_flag_value_alias(
 		ttest_report_ctx_t *report,
 		const cyaml_config_t *config)
 {
+	cyaml_config_t cfg = *config;
 	struct target_struct {
 		unsigned a;
 		unsigned b;
@@ -5165,14 +5166,16 @@ static bool test_err_load_flag_value_alias(
 	};
 	test_data_t td = {
 		.data = (cyaml_data_t **) &data_tgt,
-		.config = config,
+		.config = &cfg,
 		.schema = &top_schema,
 	};
 	cyaml_err_t err;
 
+	cfg.flags |= CYAML_CFG_NO_ALIAS;
+
 	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
 
-	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), &cfg, &top_schema,
 			(cyaml_data_t **) &data_tgt, NULL);
 	if (err != CYAML_ERR_ALIAS) {
 		return ttest_fail(&tc, cyaml_strerror(err));
@@ -5192,6 +5195,7 @@ static bool test_err_load_bitfield_value_alias_1(
 		ttest_report_ctx_t *report,
 		const cyaml_config_t *config)
 {
+	cyaml_config_t cfg = *config;
 	static const cyaml_bitdef_t bitvals[] = {
 		{ .name = "7", .offset =  0, .bits =  1 },
 		{ .name = "a", .offset =  1, .bits =  2 },
@@ -5232,14 +5236,16 @@ static bool test_err_load_bitfield_value_alias_1(
 	};
 	test_data_t td = {
 		.data = (cyaml_data_t **) &data_tgt,
-		.config = config,
+		.config = &cfg,
 		.schema = &top_schema,
 	};
 	cyaml_err_t err;
 
+	cfg.flags |= CYAML_CFG_NO_ALIAS;
+
 	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
 
-	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), &cfg, &top_schema,
 			(cyaml_data_t **) &data_tgt, NULL);
 	if (err != CYAML_ERR_ALIAS) {
 		return ttest_fail(&tc, cyaml_strerror(err));
@@ -5259,6 +5265,7 @@ static bool test_err_load_bitfield_value_alias_2(
 		ttest_report_ctx_t *report,
 		const cyaml_config_t *config)
 {
+	cyaml_config_t cfg = *config;
 	static const cyaml_bitdef_t bitvals[] = {
 		{ .name = "7", .offset =  0, .bits =  1 },
 		{ .name = "a", .offset =  1, .bits =  2 },
@@ -5299,14 +5306,16 @@ static bool test_err_load_bitfield_value_alias_2(
 	};
 	test_data_t td = {
 		.data = (cyaml_data_t **) &data_tgt,
-		.config = config,
+		.config = &cfg,
 		.schema = &top_schema,
 	};
 	cyaml_err_t err;
 
+	cfg.flags |= CYAML_CFG_NO_ALIAS;
+
 	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
 
-	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), &cfg, &top_schema,
 			(cyaml_data_t **) &data_tgt, NULL);
 	if (err != CYAML_ERR_ALIAS) {
 		return ttest_fail(&tc, cyaml_strerror(err));
@@ -5322,10 +5331,70 @@ static bool test_err_load_bitfield_value_alias_2(
  * \param[in]  config  The CYAML config to use for the test.
  * \return true if test passes, false otherwise.
  */
-static bool test_err_load_mapping_value_alias(
+static bool test_err_load_mapping_key_alias(
 		ttest_report_ctx_t *report,
 		const cyaml_config_t *config)
 {
+	cyaml_config_t cfg = *config;
+	struct target_struct {
+		char *a;
+		char *b;
+		char *c;
+		char *d;
+	};
+	static const unsigned char yaml[] =
+		"a: &example b\n"
+		"*example: test\n"
+		"c: meh\n"
+		"d: foo\n";
+	struct target_struct *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD_STRING_PTR("a", CYAML_FLAG_POINTER,
+				struct target_struct, a, 0, CYAML_UNLIMITED),
+		CYAML_FIELD_STRING_PTR("b", CYAML_FLAG_POINTER,
+				struct target_struct, b, 0, CYAML_UNLIMITED),
+		CYAML_FIELD_STRING_PTR("c", CYAML_FLAG_POINTER,
+				struct target_struct, c, 0, CYAML_UNLIMITED),
+		CYAML_FIELD_STRING_PTR("d", CYAML_FLAG_POINTER,
+				struct target_struct, d, 0, CYAML_UNLIMITED),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = &cfg,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	cfg.flags |= CYAML_CFG_NO_ALIAS;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), &cfg, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_ERR_ALIAS) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading a mapping with an aliased value.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_err_load_mapping_value_alias_1(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	cyaml_config_t cfg = *config;
 	struct target_struct {
 		char *a;
 		char *b;
@@ -5355,14 +5424,125 @@ static bool test_err_load_mapping_value_alias(
 	};
 	test_data_t td = {
 		.data = (cyaml_data_t **) &data_tgt,
-		.config = config,
+		.config = &cfg,
 		.schema = &top_schema,
 	};
 	cyaml_err_t err;
 
+	cfg.flags |= CYAML_CFG_NO_ALIAS;
+
 	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
 
-	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), &cfg, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_ERR_ALIAS) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading a mapping with an aliased value.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_err_load_mapping_value_alias_2(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	cyaml_config_t cfg = *config;
+	struct target_struct {
+		char *a;
+		char *b;
+		char *c;
+		char *d;
+	};
+	static const unsigned char yaml[] =
+		"a: 9\n"
+		"b: &foo d\n"
+		"c: *d\n";
+	struct target_struct *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD_STRING_PTR("a", CYAML_FLAG_POINTER,
+				struct target_struct, a, 0, CYAML_UNLIMITED),
+		CYAML_FIELD_STRING_PTR("b", CYAML_FLAG_POINTER,
+				struct target_struct, b, 0, CYAML_UNLIMITED),
+		CYAML_FIELD_STRING_PTR("d", CYAML_FLAG_POINTER,
+				struct target_struct, d, 0, CYAML_UNLIMITED),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = &cfg,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	cfg.flags |= CYAML_CFG_NO_ALIAS | CYAML_CFG_IGNORE_UNKNOWN_KEYS;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), &cfg, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_ERR_ALIAS) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading a mapping with an aliased value.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_err_load_mapping_value_alias_3(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	cyaml_config_t cfg = *config;
+	struct target_struct {
+		char *a;
+		char *b;
+	};
+	static const unsigned char yaml[] =
+		"a: 9\n"
+		"b: &foo d\n"
+		"c: [a, b, c, *foo]\n";
+	struct target_struct *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD_STRING_PTR("a", CYAML_FLAG_POINTER,
+				struct target_struct, a, 0, CYAML_UNLIMITED),
+		CYAML_FIELD_STRING_PTR("b", CYAML_FLAG_POINTER,
+				struct target_struct, b, 0, CYAML_UNLIMITED),
+		CYAML_FIELD_IGNORE("c", CYAML_FLAG_DEFAULT),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = &cfg,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	cfg.flags |= CYAML_CFG_NO_ALIAS;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), &cfg, &top_schema,
 			(cyaml_data_t **) &data_tgt, NULL);
 	if (err != CYAML_ERR_ALIAS) {
 		return ttest_fail(&tc, cyaml_strerror(err));
@@ -5519,7 +5699,10 @@ bool errs_tests(
 	ttest_heading(rc, "Alias tests");
 
 	pass &= test_err_load_flag_value_alias(rc, &config);
-	pass &= test_err_load_mapping_value_alias(rc, &config);
+	pass &= test_err_load_mapping_key_alias(rc, &config);
+	pass &= test_err_load_mapping_value_alias_1(rc, &config);
+	pass &= test_err_load_mapping_value_alias_2(rc, &config);
+	pass &= test_err_load_mapping_value_alias_3(rc, &config);
 	pass &= test_err_load_bitfield_value_alias_1(rc, &config);
 	pass &= test_err_load_bitfield_value_alias_2(rc, &config);
 

--- a/test/units/load.c
+++ b/test/units/load.c
@@ -5606,6 +5606,266 @@ static bool test_load_anchor_multiple_scalars(
 }
 
 /**
+ * Test loading an aliased mapping.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_anchor_mapping(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	const char *test_a = "Hello Me!";
+	const int test_b = 777;
+	static const unsigned char yaml[] =
+		"anchors:\n"
+		"  - &a2 Hello Me!\n"
+		"  - &a1 {\n"
+		"      a: *a2,\n"
+		"      b: 777,\n"
+		"    }\n"
+		"test: *a1\n";
+	struct my_test {
+		int b;
+		char *a;
+	};
+	struct target_struct {
+		struct my_test test;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field inner_mapping_schema[] = {
+		CYAML_FIELD_STRING_PTR("a", CYAML_FLAG_POINTER,
+				struct my_test, a,
+				0, CYAML_UNLIMITED),
+		CYAML_FIELD_INT("b", CYAML_FLAG_DEFAULT,
+				struct my_test, b),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD_IGNORE("anchors", CYAML_FLAG_OPTIONAL),
+		CYAML_FIELD_MAPPING("test", CYAML_FLAG_DEFAULT,
+				struct target_struct, test,
+				inner_mapping_schema),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (strcmp(data_tgt->test.a, test_a) != 0) {
+		return ttest_fail(&tc, "Incorrect value: "
+				"expected: %s, got: %s",
+				test_a, data_tgt->test.a);
+	}
+
+	if (data_tgt->test.b != test_b) {
+		return ttest_fail(&tc, "Incorrect value: "
+				"expected: %i, got: %i",
+				test_b, data_tgt->test.b);
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading an aliased sequence.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_anchor_sequence(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	const int test_a[] = { 1, 22, 333, 4444 };
+	static const unsigned char yaml[] =
+		"anchors:\n"
+		"  - &a1 [\n"
+		"      1,\n"
+		"      22,\n"
+		"      333,\n"
+		"      4444,\n"
+		"    ]\n"
+		"test: *a1\n";
+	struct target_struct {
+		int *a;
+		unsigned a_count;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_value sequence_entry_schema = {
+		CYAML_VALUE_INT(CYAML_FLAG_DEFAULT, int),
+	};
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD_IGNORE("anchors", CYAML_FLAG_OPTIONAL),
+		CYAML_FIELD_SEQUENCE("test", CYAML_FLAG_POINTER,
+				struct target_struct, a,
+				&sequence_entry_schema,
+				0, CYAML_UNLIMITED),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (data_tgt->a_count != CYAML_ARRAY_LEN(test_a)) {
+		return ttest_fail(&tc, "Incorrect value: "
+				"expected: %u, got: %u",
+				data_tgt->a_count, CYAML_ARRAY_LEN(test_a));
+	}
+
+	for (unsigned i = 0; i < CYAML_ARRAY_LEN(test_a); i++) {
+		if (data_tgt->a[i] != test_a[i]) {
+			return ttest_fail(&tc, "Incorrect value: "
+					"expected: %i, got: %i",
+					data_tgt->a[i], test_a[i]);
+		}
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading with anchors within anchors, etc.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_anchor_deep_mapping_sequence(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	const char *test_a = "Hello Me!";
+	const int test_b[] = { 1, 22, 333, 4444 };
+	static const unsigned char yaml[] =
+		"anchors:\n"
+		"  - &a1 Hello Me!\n"
+		"  - &a2 {\n"
+		"      a: *a1,\n"
+		"      b: &a3 [ 1, 22, 333, 4444 ],\n"
+		"      c: *a1,\n"
+		"      d: *a3,\n"
+		"    }\n"
+		"test_a: *a2\n"
+		"test_b: *a3\n";
+	struct my_test {
+		char *a;
+		int *b;
+		unsigned b_count;
+		char *c;
+		int *d;
+		unsigned d_count;
+	};
+	struct target_struct {
+		struct my_test test_a;
+		int *test_b;
+		unsigned test_b_count;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_value sequence_entry_schema = {
+		CYAML_VALUE_INT(CYAML_FLAG_DEFAULT, int),
+	};
+	static const struct cyaml_schema_field inner_mapping_schema[] = {
+		CYAML_FIELD_STRING_PTR("a", CYAML_FLAG_POINTER,
+				struct my_test, a, 0, CYAML_UNLIMITED),
+		CYAML_FIELD_SEQUENCE("b", CYAML_FLAG_POINTER, struct my_test, b,
+				&sequence_entry_schema, 0, CYAML_UNLIMITED),
+		CYAML_FIELD_STRING_PTR("c", CYAML_FLAG_POINTER,
+				struct my_test, c, 0, CYAML_UNLIMITED),
+		CYAML_FIELD_SEQUENCE("d", CYAML_FLAG_POINTER, struct my_test, d,
+				&sequence_entry_schema, 0, CYAML_UNLIMITED),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD_IGNORE("anchors", CYAML_FLAG_OPTIONAL),
+		CYAML_FIELD_MAPPING("test_a", CYAML_FLAG_DEFAULT,
+				struct target_struct, test_a,
+				inner_mapping_schema),
+		CYAML_FIELD_SEQUENCE("test_b", CYAML_FLAG_POINTER,
+				struct target_struct, test_b,
+				&sequence_entry_schema,
+				0, CYAML_UNLIMITED),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (strcmp(data_tgt->test_a.a, test_a) != 0) {
+		return ttest_fail(&tc, "Incorrect value: "
+				"expected: %s, got: %s",
+				test_a, data_tgt->test_a.a);
+	}
+
+	if (strcmp(data_tgt->test_a.c, test_a) != 0) {
+		return ttest_fail(&tc, "Incorrect value: "
+				"expected: %s, got: %s",
+				test_a, data_tgt->test_a.c);
+	}
+
+	if (data_tgt->test_b_count != CYAML_ARRAY_LEN(test_b)) {
+		return ttest_fail(&tc, "Incorrect value: "
+				"expected: %u, got: %u",
+				data_tgt->test_b_count,
+				CYAML_ARRAY_LEN(test_b));
+	}
+
+	for (unsigned i = 0; i < CYAML_ARRAY_LEN(test_b); i++) {
+		if (data_tgt->test_b[i] != test_b[i]) {
+			return ttest_fail(&tc, "Incorrect value: "
+					"expected: %i, got: %i",
+					data_tgt->test_b[i], test_b[i]);
+		}
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
  * Run the YAML loading unit tests.
  *
  * \param[in]  rc         The ttest report context.
@@ -5732,6 +5992,12 @@ bool load_tests(
 	pass &= test_load_anchor_scalar_int(rc, &config);
 	pass &= test_load_anchor_scalar_string(rc, &config);
 	pass &= test_load_anchor_multiple_scalars(rc, &config);
+
+	ttest_heading(rc, "Load tests: anchors and aliases (non scalars)");
+
+	pass &= test_load_anchor_mapping(rc, &config);
+	pass &= test_load_anchor_sequence(rc, &config);
+	pass &= test_load_anchor_deep_mapping_sequence(rc, &config);
 
 	return pass;
 }

--- a/test/units/load.c
+++ b/test/units/load.c
@@ -5349,6 +5349,263 @@ static bool test_load_mapping_fields_value_insensitive_1(
 }
 
 /**
+ * Test loading with an unused anchor.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_unused_anchor(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	const char *string_value = "Hello World!";
+	const int int_value = 9;
+	static const unsigned char yaml[] =
+		"test_string: &foo Hello World!\n"
+		"test_int: 9\n";
+	struct target_struct {
+		char * test_value_string;
+		int test_value_int;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD_STRING_PTR("test_string", CYAML_FLAG_POINTER,
+				struct target_struct, test_value_string,
+				0, CYAML_UNLIMITED),
+		CYAML_FIELD_INT("test_int", CYAML_FLAG_DEFAULT,
+				struct target_struct, test_value_int),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (strcmp(data_tgt->test_value_string, string_value) != 0) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	if (data_tgt->test_value_int != int_value) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading with an aliased string value.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_anchor_scalar_int(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	const char *string_value = "Hello World!";
+	const int int_value = 9;
+	static const unsigned char yaml[] =
+		"test_int_anchor: &foo 9\n"
+		"test_string: Hello World!\n"
+		"test_int: *foo\n";
+	struct target_struct {
+		char * test_value_string;
+		int test_value_int;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD_IGNORE("test_int_anchor", CYAML_FLAG_OPTIONAL),
+		CYAML_FIELD_STRING_PTR("test_string", CYAML_FLAG_POINTER,
+				struct target_struct, test_value_string,
+				0, CYAML_UNLIMITED),
+		CYAML_FIELD_INT("test_int", CYAML_FLAG_DEFAULT,
+				struct target_struct, test_value_int),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (strcmp(data_tgt->test_value_string, string_value) != 0) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	if (data_tgt->test_value_int != int_value) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading with an aliased string value.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_anchor_scalar_string(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	const char *string_value = "Hello World!";
+	const int int_value = 9;
+	static const unsigned char yaml[] =
+		"test_string_anchor: &foo Hello World!\n"
+		"test_string: *foo\n"
+		"test_int: 9\n";
+	struct target_struct {
+		char * test_value_string;
+		int test_value_int;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD_IGNORE("test_string_anchor", CYAML_FLAG_OPTIONAL),
+		CYAML_FIELD_STRING_PTR("test_string", CYAML_FLAG_POINTER,
+				struct target_struct, test_value_string,
+				0, CYAML_UNLIMITED),
+		CYAML_FIELD_INT("test_int", CYAML_FLAG_DEFAULT,
+				struct target_struct, test_value_int),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (strcmp(data_tgt->test_value_string, string_value) != 0) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	if (data_tgt->test_value_int != int_value) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading multiple anchored and alisased scalars.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_anchor_multiple_scalars(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	const char *string_value1 = "Hello Me!";
+	const char *string_value2 = "Hello World!";
+	const int int_value = 99;
+	static const unsigned char yaml[] =
+		"anchors:\n"
+		"  - &a1 Hello World!\n"
+		"  - &a2 Hello Me!\n"
+		"  - &a3 99\n"
+		"test_string1: *a2\n"
+		"test_int: *a3\n"
+		"test_string2: *a1\n";
+	struct target_struct {
+		char * test_value_string1;
+		char * test_value_string2;
+		int test_value_int;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD_IGNORE("anchors", CYAML_FLAG_OPTIONAL),
+		CYAML_FIELD_STRING_PTR("test_string1", CYAML_FLAG_POINTER,
+				struct target_struct, test_value_string1,
+				0, CYAML_UNLIMITED),
+		CYAML_FIELD_STRING_PTR("test_string2", CYAML_FLAG_POINTER,
+				struct target_struct, test_value_string2,
+				0, CYAML_UNLIMITED),
+		CYAML_FIELD_INT("test_int", CYAML_FLAG_DEFAULT,
+				struct target_struct, test_value_int),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (strcmp(data_tgt->test_value_string1, string_value1) != 0) {
+		return ttest_fail(&tc, "Incorrect value: "
+				"expected: %s, got: %s",
+				string_value1, data_tgt->test_value_string1);
+	}
+
+	if (strcmp(data_tgt->test_value_string2, string_value2) != 0) {
+		return ttest_fail(&tc, "Incorrect value: "
+				"expected: %s, got: %s",
+				string_value2, data_tgt->test_value_string2);
+	}
+
+	if (data_tgt->test_value_int != int_value) {
+		return ttest_fail(&tc, "Incorrect value: "
+				"expected: %i, got: %i",
+				int_value, data_tgt->test_value_int);
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
  * Run the YAML loading unit tests.
  *
  * \param[in]  rc         The ttest report context.
@@ -5468,6 +5725,13 @@ bool load_tests(
 	pass &= test_load_mapping_fields_cfg_insensitive_3(rc, &config);
 	pass &= test_load_mapping_fields_value_sensitive_1(rc, &config);
 	pass &= test_load_mapping_fields_value_insensitive_1(rc, &config);
+
+	ttest_heading(rc, "Load tests: anchors and aliases (scalars)");
+
+	pass &= test_load_unused_anchor(rc, &config);
+	pass &= test_load_anchor_scalar_int(rc, &config);
+	pass &= test_load_anchor_scalar_string(rc, &config);
+	pass &= test_load_anchor_multiple_scalars(rc, &config);
 
 	return pass;
 }

--- a/test/units/ttest.h
+++ b/test/units/ttest.h
@@ -141,15 +141,17 @@ static inline bool ttest_fail(
 	assert(tc != NULL);
 	assert(tc->report != NULL);
 
-	if (tc->cleanup != NULL) {
-		tc->cleanup(tc->cleanup_data);
-	}
-
 	fprintf(stderr, "  FAIL: %s (", tc->name);
 	va_start(args, reason);
 	vfprintf(stderr, reason, args);
 	va_end(args);
 	fprintf(stderr, ")\n");
+
+	/* Cleanup after printing result, in case `reason` refers to cleaned up
+	 * memory. */
+	if (tc->cleanup != NULL) {
+		tc->cleanup(tc->cleanup_data);
+	}
 
 	return false;
 }

--- a/test/units/util.c
+++ b/test/units/util.c
@@ -69,6 +69,38 @@ static bool test_util_memory_funcs(
 }
 
 /**
+ * Test cyaml memory functions.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_util_strdup(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	ttest_ctx_t tc = ttest_start(report, __func__, NULL, NULL);
+	const char *orig = "Hello!";
+	char *copy;
+
+	/* Create test allocation */
+	copy = cyaml__strdup(config, orig);
+	if (copy == NULL) {
+		return ttest_fail(&tc, "Memory allocation failed.");
+	}
+
+	/* Check allocation was zeroed. */
+	if (strcmp(orig, copy) != 0) {
+		return ttest_fail(&tc, "String not copied correctly.");
+	}
+
+	/* Free test allocation. */
+	cyaml__free(config, copy);
+
+	return ttest_pass(&tc);
+}
+
+/**
  * Test invalid state machine state.
  *
  * \param[in]  report  The test report context.
@@ -200,6 +232,7 @@ bool util_tests(
 
 	ttest_heading(rc, "Memory utility functions");
 
+	pass &= test_util_strdup(rc, &config);
 	pass &= test_util_memory_funcs(rc, &config);
 
 	ttest_heading(rc, "Error code tests");


### PR DESCRIPTION
This allows any anchored events (even ignored ones) to be
recorded, and replayed in place of aliases.  The merge key
is not yet supported.
