### PR TITLE
Makefile: optionally use pkg-config to find libyaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,14 @@ VERSION_FLAGS = -DVERSION_MAJOR=$(VERSION_MAJOR) \
                 -DVERSION_PATCH=$(VERSION_PATCH) \
                 -DVERSION_DEVEL=$(VERSION_DEVEL)
 
+LIBYAML = yaml-0.1
+LIBYAML_CFLAGS := $(if $(PKG_CONFIG),$(shell $(PKG_CONFIG) --cflags $(LIBYAML)),)
+LIBYAML_LIBS := $(if $(PKG_CONFIG),$(shell $(PKG_CONFIG) --libs $(LIBYAML)),-lyaml)
+
 INCLUDE = -I include
-CFLAGS += $(INCLUDE) $(VERSION_FLAGS)
+CFLAGS += $(INCLUDE) $(VERSION_FLAGS) $(LIBYAML_CFLAGS)
 CFLAGS += -std=c11 -Wall -Wextra -pedantic
-LDFLAGS += -lyaml
+LDFLAGS += $(LIBYAML_LIBS)
 LDFLAGS_SHARED += -Wl,-soname=$(LIB_SH_MAJ) -shared
 
 ifeq ($(VARIANT), debug)


### PR DESCRIPTION
Compile with `make PKG_CONFIG=pkg-config` to enable this feature.
Otherwise the build works as before. This also allows you to
compile with libyaml in a non-standard place without using
pkg-config. Eg.:
```sh
make \
  LIBYAML_CFLAGS=-I$HOME/local/include \
  LIBYAML_LIBS="-L$HOME/local/lib -lyaml"
```