### PR TITLE
Tlsa/allow null pointer values

### DIFF
--- a/include/cyaml/cyaml.h
+++ b/include/cyaml/cyaml.h
@@ -132,7 +132,47 @@ typedef enum cyaml_type {
 typedef enum cyaml_flag {
 	CYAML_FLAG_DEFAULT  = 0,        /**< Default value flags (none set). */
 	CYAML_FLAG_OPTIONAL = (1 << 0), /**< Mapping field is optional. */
-	CYAML_FLAG_POINTER  = (1 << 1), /**< Value is a pointer to its type. */
+	/**
+	 * Value is a pointer to its type.
+	 *
+	 * With this there must be a non-NULL value.  Consider using
+	 * \ref CYAML_FLAG_POINTER_NULL or \ref CYAML_FLAG_POINTER_NULL_STR
+	 * if you want to allow NULL values.
+	 */
+	CYAML_FLAG_POINTER  = (1 << 1),
+	/**
+	 * Permit `NULL` values for \ref CYAML_FLAG_POINTER types.
+	 *
+	 * An empty value in the YAML is loaded as a NULL pointer, and NULL
+	 * pointers are saved in YAML as empty values.
+	 *
+	 * Note, when you set \ref CYAML_FLAG_POINTER_NULL, then
+	 * \ref CYAML_FLAG_POINTER is set automatically.
+	 */
+	CYAML_FLAG_POINTER_NULL = (1 << 2) | CYAML_FLAG_POINTER,
+	/**
+	 * Permit storage of `NULL` values as special NULL strings in YAML.
+	 *
+	 * This extends \ref CYAML_FLAG_POINTER_NULL, but in addition to
+	 * treating empty values as NULL, any of the following are also treated
+	 * as NULL:
+	 *
+	 * * `null`,
+	 * * `Null`,
+	 * * `NULL`,
+	 * * `~`,
+	 *
+	 * Note that as a side effect, loading a \ref CYAML_STRING field with
+	 * one of these values will not store the literal string, it will store
+	 * NULL.
+	 *
+	 * When saving, a NULL value will be recorded in the YAML as `null`.
+	 *
+	 * Note, when you set \ref CYAML_FLAG_POINTER_NULL_STR, then both
+	 * \ref CYAML_FLAG_POINTER and \ref CYAML_FLAG_POINTER_NULL are set
+	 * automatically.
+	 */
+	CYAML_FLAG_POINTER_NULL_STR = (1 << 3) | CYAML_FLAG_POINTER_NULL,
 	/**
 	 * Make value handling strict.
 	 *
@@ -145,7 +185,7 @@ typedef enum cyaml_flag {
 	 * * For \ref CYAML_FLAGS, the values are bitwise ORed together.
 	 *   The numerical values are treated as unsigned,
 	 */
-	CYAML_FLAG_STRICT   = (1 << 2),
+	CYAML_FLAG_STRICT   = (1 << 4),
 	/**
 	 * When saving, emit mapping / sequence value in block style.
 	 *
@@ -162,7 +202,7 @@ typedef enum cyaml_flag {
 	 *       \ref cyaml_cfg_flags CYAML behavioural configuration flags,
 	 *       then libyaml's default behaviour is used.
 	 */
-	CYAML_FLAG_BLOCK    = (1 << 3),
+	CYAML_FLAG_BLOCK    = (1 << 5),
 	/**
 	 * When saving, emit mapping / sequence value in flow style.
 	 *
@@ -179,7 +219,7 @@ typedef enum cyaml_flag {
 	 *       \ref cyaml_cfg_flags CYAML behavioural configuration flags,
 	 *       then libyaml's default behaviour is used.
 	 */
-	CYAML_FLAG_FLOW     = (1 << 4),
+	CYAML_FLAG_FLOW     = (1 << 6),
 	/**
 	 * When comparing strings for this value, compare with case sensitivity.
 	 *
@@ -197,7 +237,7 @@ typedef enum cyaml_flag {
 	 *       enums and flags it applies to the comparison of
 	 *       \ref cyaml_strval strings.
 	 */
-	CYAML_FLAG_CASE_SENSITIVE   = (1 << 5),
+	CYAML_FLAG_CASE_SENSITIVE   = (1 << 7),
 	/**
 	 * When comparing strings for this value, compare with case sensitivity.
 	 *
@@ -215,7 +255,7 @@ typedef enum cyaml_flag {
 	 *       enums and flags it applies to the comparison of
 	 *       \ref cyaml_strval strings.
 	 */
-	CYAML_FLAG_CASE_INSENSITIVE = (1 << 6),
+	CYAML_FLAG_CASE_INSENSITIVE = (1 << 8),
 } cyaml_flag_e;
 
 /**

--- a/src/load.c
+++ b/src/load.c
@@ -1639,7 +1639,7 @@ static cyaml_err_t cyaml__read_flags_value(
 /**
  * Set some bits in a \ref CYAML_BITFIELD value.
  *
- * If the fiven bit value name is one expected by the schema, then this
+ * If the given bit value name is one expected by the schema, then this
  * function consumes an event from the YAML input stream.
  *
  * \param[in]      ctx        The CYAML loading context.

--- a/src/save.c
+++ b/src/save.c
@@ -1106,8 +1106,7 @@ static cyaml_err_t cyaml__write_mapping(
 			}
 		}
 
-		err = cyaml__emit_scalar(ctx, NULL, field->key,
-				YAML_STR_TAG);
+		err = cyaml__emit_scalar(ctx, NULL, field->key, YAML_STR_TAG);
 		if (err != CYAML_OK) {
 			return err;
 		}

--- a/src/save.c
+++ b/src/save.c
@@ -975,6 +975,20 @@ static cyaml_err_t cyaml__write_value(
 
 	data = cyaml__data_handle_pointer(ctx->config, schema, data);
 
+	if (data == NULL) {
+		if (cyaml__flag_check_all(schema->flags,
+				CYAML_FLAG_POINTER_NULL_STR)) {
+			return cyaml__emit_scalar(ctx, schema, "null",
+					YAML_STR_TAG);
+		} else if (cyaml__flag_check_all(schema->flags,
+				CYAML_FLAG_POINTER_NULL)) {
+			return cyaml__emit_scalar(ctx, schema, "",
+					YAML_STR_TAG);
+		} else {
+			return CYAML_ERR_INVALID_VALUE;
+		}
+	}
+
 	switch (schema->type) {
 	case CYAML_INT:   /* Fall through. */
 	case CYAML_UINT:  /* Fall through. */

--- a/src/util.h
+++ b/src/util.h
@@ -167,4 +167,18 @@ static inline int cyaml__strcmp(
 	return cyaml_utf8_casecmp(str1, str2);
 }
 
+/**
+ * Check of all the bits of a mask are set in a cyaml value flag word.
+ *
+ * \param[in] flags  The value flags to test.
+ * \param[in] mask   Mask of the bits to test for in flags.
+ * \return true if all bits of mask are set in flags.
+ */
+static inline bool cyaml__flag_check_all(
+		enum cyaml_flag flags,
+		enum cyaml_flag mask)
+{
+	return ((flags & mask) == mask);
+}
+
 #endif

--- a/test/units/errs.c
+++ b/test/units/errs.c
@@ -1931,10 +1931,11 @@ static bool test_err_save_schema_sequence_min_max(
 		ttest_report_ctx_t *report,
 		const cyaml_config_t *config)
 {
+	unsigned value = 5;
 	struct target_struct {
 		unsigned *seq;
 	} data = {
-		.seq = NULL,
+		.seq = &value,
 	};
 	static const struct cyaml_schema_value entry_schema = {
 		CYAML_VALUE_UINT(CYAML_FLAG_DEFAULT, *(data.seq)),

--- a/test/units/errs.c
+++ b/test/units/errs.c
@@ -2382,6 +2382,48 @@ static bool test_err_load_schema_invalid_value_flags_3(
 }
 
 /**
+ * Test saving a NULL when NULLs aren't allowed by the schema.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_err_save_schema_invalid_value_null_ptr(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	static const int d[] = { 7, 6, 5, 4, 3, 2, 1, 0 };
+	static const int *data[] = { d + 0, d + 1, d + 2, NULL,
+	                             d + 4, d + 5, d + 6, d + 7, };
+	static const struct cyaml_schema_value entry_schema = {
+		CYAML_VALUE_INT(CYAML_FLAG_POINTER, int)
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_SEQUENCE(CYAML_FLAG_POINTER, int,
+				&entry_schema, 0, 3),
+	};
+	char *buffer = NULL;
+	size_t len = 0;
+	cyaml_config_t cfg = *config;
+	test_data_t td = {
+		.buffer = &buffer,
+		.config = &cfg,
+	};
+	cyaml_err_t err;
+
+	cfg.flags |= CYAML_CFG_STYLE_BLOCK;
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_save_data(&buffer, &len, &cfg, &top_schema, data,
+			CYAML_ARRAY_LEN(data));
+	if (err != CYAML_ERR_INVALID_VALUE) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
  * Test loading when schema expects bitfield, but numerical value is invalid.
  *
  * \param[in]  report  The test report context.
@@ -5760,6 +5802,7 @@ bool errs_tests(
 	pass &= test_err_load_schema_invalid_value_flags_1(rc, &config);
 	pass &= test_err_load_schema_invalid_value_flags_2(rc, &config);
 	pass &= test_err_load_schema_invalid_value_flags_3(rc, &config);
+	pass &= test_err_save_schema_invalid_value_null_ptr(rc, &config);
 	pass &= test_err_load_schema_invalid_value_bitfield_1(rc, &config);
 	pass &= test_err_load_schema_invalid_value_bitfield_2(rc, &config);
 	pass &= test_err_load_schema_invalid_value_bitfield_3(rc, &config);

--- a/test/units/load.c
+++ b/test/units/load.c
@@ -966,7 +966,7 @@ static bool test_load_mapping_entry_string(
 }
 
 /**
- * Test loading a string to a allocated char pointer.
+ * Test loading a string to an allocated char pointer.
  *
  * \param[in]  report  The test report context.
  * \param[in]  config  The CYAML config to use for the test.
@@ -976,9 +976,9 @@ static bool test_load_mapping_entry_string_ptr(
 		ttest_report_ctx_t *report,
 		const cyaml_config_t *config)
 {
-	const char *value = "Hello World!";
+	const char *value = "null";
 	static const unsigned char yaml[] =
-		"test_string: Hello World!\n";
+		"test_string: null\n";
 	struct target_struct {
 		char * test_value_string;
 	} *data_tgt = NULL;
@@ -1008,6 +1008,154 @@ static bool test_load_mapping_entry_string_ptr(
 	}
 
 	if (strcmp(data_tgt->test_value_string, value) != 0) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading an empty string to an allocated char pointer.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_mapping_entry_string_ptr_empty(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	const char *value = "";
+	static const unsigned char yaml[] =
+		"test_string:\n";
+	struct target_struct {
+		char * test_value_string;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD_STRING_PTR("test_string", CYAML_FLAG_POINTER,
+				struct target_struct, test_value_string,
+				0, CYAML_UNLIMITED),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (strcmp(data_tgt->test_value_string, value) != 0) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading a null string to an allocated nullable char pointer.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_mapping_entry_string_ptr_null_str(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	const char *value = NULL;
+	static const unsigned char yaml[] =
+		"test_string: null\n";
+	struct target_struct {
+		char * test_value_string;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD_STRING_PTR("test_string",
+				CYAML_FLAG_POINTER_NULL_STR,
+				struct target_struct, test_value_string,
+				0, CYAML_UNLIMITED),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (data_tgt->test_value_string != value) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading an empty string to an allocated nullable char pointer.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_mapping_entry_string_ptr_null_empty(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	const char *value = NULL;
+	static const unsigned char yaml[] =
+		"test_string:\n";
+	struct target_struct {
+		char * test_value_string;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD_STRING_PTR("test_string", CYAML_FLAG_POINTER_NULL,
+				struct target_struct, test_value_string,
+				0, CYAML_UNLIMITED),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (data_tgt->test_value_string != value) {
 		return ttest_fail(&tc, "Incorrect value");
 	}
 
@@ -3497,6 +3645,241 @@ static bool test_load_mapping_entry_sequence_ptr_sequence_fixed_flat_int(
 						"got: %i, expected: %i", i, j,
 						data_tgt->seq[j * CYAML_ARRAY_LEN(*ref) + i],
 						ref[j][i]);
+			}
+		}
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading sequence of pointers to integer values with NULLs.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_sequence_null_str_values_int(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	static const int expected[] = {
+		777, 6, 5, 4, 3, 2, 1, 0,
+	};
+	static const bool expected_nulls[] = {
+		false, false, false, true, false, false, true, false,
+	};
+	static const unsigned char yaml[] =
+		"- 777\n"
+		"- 6\n"
+		"- 5\n"
+		"- ~\n"
+		"- 3\n"
+		"- 2\n"
+		"- null\n"
+		"- 0\n";
+	int **value = NULL;
+	unsigned count = 0;
+	static const struct cyaml_schema_value entry_schema = {
+		CYAML_VALUE_INT(CYAML_FLAG_POINTER_NULL_STR, **value)
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_SEQUENCE(CYAML_FLAG_POINTER, *value,
+				&entry_schema, 0, CYAML_UNLIMITED)
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &value,
+		.seq_count = &count,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &value, &count);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (count != CYAML_ARRAY_LEN(expected)) {
+		return ttest_fail(&tc, "Unexpected sequence count.");
+	}
+
+	if (value == NULL) {
+		return ttest_fail(&tc, "Data NULL on success.");
+	}
+
+	for (unsigned i = 0; i < CYAML_ARRAY_LEN(expected); i ++) {
+		if (expected_nulls[i]) {
+			if (value[i] != NULL) {
+				return ttest_fail(&tc, "Expected NULL.");
+			}
+			continue;
+		} else {
+			if (value[i] == NULL) {
+				return ttest_fail(&tc, "Unexpected NULL.");
+			}
+			if ((*(value)[i]) != expected[i]) {
+				return ttest_fail(&tc, "Bad value.");
+			}
+		}
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading sequence of pointers to integer values with NULLs.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_sequence_null_values_int(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	static const int expected[] = {
+		777, 6, 5, 4, 3, 2, 1, 0,
+	};
+	static const bool expected_nulls[] = {
+		false, false, false, true, false, false, true, false,
+	};
+	static const unsigned char yaml[] =
+		"- 777\n"
+		"- 6\n"
+		"- 5\n"
+		"- \n"
+		"- 3\n"
+		"- 2\n"
+		"- \n"
+		"- 0\n";
+	int **value = NULL;
+	unsigned count = 0;
+	static const struct cyaml_schema_value entry_schema = {
+		CYAML_VALUE_INT(CYAML_FLAG_POINTER_NULL, **value)
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_SEQUENCE(CYAML_FLAG_POINTER, *value,
+				&entry_schema, 0, CYAML_UNLIMITED)
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &value,
+		.seq_count = &count,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &value, &count);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (count != CYAML_ARRAY_LEN(expected)) {
+		return ttest_fail(&tc, "Unexpected sequence count.");
+	}
+
+	if (value == NULL) {
+		return ttest_fail(&tc, "Data NULL on success.");
+	}
+
+	for (unsigned i = 0; i < CYAML_ARRAY_LEN(expected); i ++) {
+		if (expected_nulls[i]) {
+			if (value[i] != NULL) {
+				return ttest_fail(&tc, "Expected NULL.");
+			}
+			continue;
+		} else {
+			if (value[i] == NULL) {
+				return ttest_fail(&tc, "Unexpected NULL.");
+			}
+			if ((*(value)[i]) != expected[i]) {
+				return ttest_fail(&tc, "Bad value.");
+			}
+		}
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading sequence of pointers to integer values with NULLs.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_sequence_null_str_values_uint(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	static const int expected[] = {
+		7, 6, 5555, 4, 3, 2, 1, 0,
+	};
+	static const bool expected_nulls[] = {
+		false, true, false, true, false, false, true, false,
+	};
+	static const unsigned char yaml[] =
+		"- 7\n"
+		"- \n"
+		"- 5555\n"
+		"- Null\n"
+		"- 3\n"
+		"- 2\n"
+		"- NULL\n"
+		"- 0\n";
+	int **value = NULL;
+	unsigned count = 0;
+	static const struct cyaml_schema_value entry_schema = {
+		CYAML_VALUE_INT(CYAML_FLAG_POINTER_NULL_STR,
+				**value)
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_SEQUENCE(CYAML_FLAG_POINTER, *value,
+				&entry_schema, 0, CYAML_UNLIMITED)
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &value,
+		.seq_count = &count,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+
+	ttest_ctx_t tc = ttest_start(report, __func__, cyaml_cleanup, &td);
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &value, &count);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (count != CYAML_ARRAY_LEN(expected)) {
+		return ttest_fail(&tc, "Unexpected sequence count.");
+	}
+
+	if (value == NULL) {
+		return ttest_fail(&tc, "Data NULL on success.");
+	}
+
+	for (unsigned i = 0; i < CYAML_ARRAY_LEN(expected); i ++) {
+		if (expected_nulls[i]) {
+			if (value[i] != NULL) {
+				return ttest_fail(&tc, "Expected NULL.");
+			}
+			continue;
+		} else {
+			if (value[i] == NULL) {
+				return ttest_fail(&tc, "Unexpected NULL.");
+			}
+			if ((*(value)[i]) != expected[i]) {
+				return ttest_fail(&tc, "Bad value.");
 			}
 		}
 	}
@@ -5996,6 +6379,9 @@ bool load_tests(
 	pass &= test_load_mapping_entry_ignore_scalar(rc, &config);
 	pass &= test_load_mapping_entry_bool_true_ptr(rc, &config);
 	pass &= test_load_mapping_entry_bool_false_ptr(rc, &config);
+	pass &= test_load_mapping_entry_string_ptr_empty(rc, &config);
+	pass &= test_load_mapping_entry_string_ptr_null_str(rc, &config);
+	pass &= test_load_mapping_entry_string_ptr_null_empty(rc, &config);
 
 	ttest_heading(rc, "Load single entry mapping tests: complex types");
 
@@ -6037,6 +6423,12 @@ bool load_tests(
 	pass &= test_load_mapping_entry_sequence_ptr_sequence_fixed_int(rc, &config);
 	pass &= test_load_mapping_entry_sequence_ptr_sequence_fixed_ptr_int(rc, &config);
 	pass &= test_load_mapping_entry_sequence_ptr_sequence_fixed_flat_int(rc, &config);
+
+	ttest_heading(rc, "Load tests: ptr sequence with null values");
+
+	pass &= test_load_sequence_null_values_int(rc, &config);
+	pass &= test_load_sequence_null_str_values_int(rc, &config);
+	pass &= test_load_sequence_null_str_values_uint(rc, &config);
 
 	ttest_heading(rc, "Load tests: sequence count sizes");
 


### PR DESCRIPTION
Allow pointer values to have a `NULL` value.

Implements https://github.com/tlsa/libcyaml/issues/98.