### PR TITLE
API: Allow client to provide a context pointer for logging.

### DIFF
--- a/include/cyaml/cyaml.h
+++ b/include/cyaml/cyaml.h
@@ -1321,11 +1321,13 @@ typedef enum cyaml_log_e {
  * Otherwise, consider using the standard logging function, \ref cyaml_log.
  *
  * \param[in] level  Log level of message to log.
+ * \param[in] ctx    Client's private logging context.
  * \param[in] fmt    Format string for message to log.
  * \param[in] args   Additional arguments used by fmt.
  */
 typedef void (*cyaml_log_fn_t)(
 		cyaml_log_t level,
+		void *ctx,
 		const char *fmt,
 		va_list args);
 
@@ -1370,6 +1372,16 @@ typedef struct cyaml_config {
 	 *       be rejected by your schema.
 	 */
 	cyaml_log_fn_t log_fn;
+	/**
+	 * Client logging function context pointer.
+	 *
+	 * Clients using their own custom logging function can pass their
+	 * context here, which will be passed through to their log_fn.
+	 *
+	 * The default logging function, \ref cyaml_log doesn't require a
+	 * logging context, so pass NULL for the log_ctx if using that.
+	 */
+	void *log_ctx;
 	/**
 	 * Client function to use for memory allocation handling.
 	 *
@@ -1417,11 +1429,13 @@ typedef struct cyaml_config {
  *       pass it in via \ref cyaml_config_t.
  *
  * \param[in] level  Log level of message to log.
+ * \param[in] ctx    Logging context, unused.
  * \param[in] fmt    Format string for message to log.
  * \param[in] args   Additional arguments used by fmt.
  */
 extern void cyaml_log(
 		cyaml_log_t level,
+		void *ctx,
 		const char *fmt,
 		va_list args);
 

--- a/src/util.c
+++ b/src/util.c
@@ -59,6 +59,7 @@ const char *cyaml_version_str = CYAML_VERSION_STR;
 /* Exported function, documented in include/cyaml/cyaml.h */
 void cyaml_log(
 		cyaml_log_t level,
+		void *ctx,
 		const char *fmt,
 		va_list args)
 {
@@ -69,6 +70,9 @@ void cyaml_log(
 		[CYAML_LOG_WARNING] = "WARNING",
 		[CYAML_LOG_ERROR]   = "ERROR",
 	};
+
+	CYAML_UNUSED(ctx);
+
 	fprintf(stderr, "libcyaml: %7.7s: ", strings[level]);
 	vfprintf(stderr, fmt, args);
 }

--- a/src/util.h
+++ b/src/util.h
@@ -110,7 +110,7 @@ static inline void cyaml__log(
 	if (level >= cfg->log_level && cfg->log_fn != NULL) {
 		va_list args;
 		va_start(args, fmt);
-		cfg->log_fn(level, fmt, args);
+		cfg->log_fn(level, cfg->log_ctx, fmt, args);
 		va_end(args);
 	}
 }


### PR DESCRIPTION
Extends the CYAML config structure to contain a log_ctx void pointer member, which is passed out to client's custom logging functions.