### PR TITLE
Tlsa/default branch main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-    - master
+    - main
 jobs:
   gcc:
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -2,10 +2,10 @@ name: Coverage
 on:
   pull_request:
     branches:
-    - master
+    - main
   push:
     branches:
-    - master
+    - main
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 LibCYAML: Schema-based YAML parsing and serialisation
 =====================================================
 
-[![Build Status](https://github.com/tlsa/libcyaml/workflows/CI/badge.svg)](https://github.com/tlsa/libcyaml/actions) [![Code Coverage](https://codecov.io/gh/tlsa/libcyaml/branch/master/graph/badge.svg)](https://codecov.io/gh/tlsa/libcyaml) [![Code Quality](https://img.shields.io/lgtm/grade/cpp/g/tlsa/libcyaml.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/tlsa/libcyaml/alerts/)
+[![Build Status](https://github.com/tlsa/libcyaml/workflows/CI/badge.svg)](https://github.com/tlsa/libcyaml/actions) [![Code Coverage](https://codecov.io/gh/tlsa/libcyaml/branch/main/graph/badge.svg)](https://codecov.io/gh/tlsa/libcyaml) [![Code Quality](https://img.shields.io/lgtm/grade/cpp/g/tlsa/libcyaml.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/tlsa/libcyaml/alerts/)
 
 LibCYAML is a C library for reading and writing structured YAML documents.
 It is written in ISO C11 and licensed under the ISC licence.
@@ -101,7 +101,7 @@ internals, `doxygen` is required:
     make docs
 
 Alternatively, the read the API documentation directly from the
-[cyaml.h](https://github.com/tlsa/libcyaml/blob/master/include/cyaml/cyaml.h)
+[cyaml.h](https://github.com/tlsa/libcyaml/blob/main/include/cyaml/cyaml.h)
 header file.
 
 There is also a [tutorial](docs/guide.md).

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -51,7 +51,7 @@ struct numbers {
 Then we need to define a CYAML schema to describe these to LibCYAML.
 
 > **Note**: Use the doxygen API documentation, or else the documentation in
-> [cyaml.h](https://github.com/tlsa/libcyaml/blob/master/include/cyaml/cyaml.h)
+> [cyaml.h](https://github.com/tlsa/libcyaml/blob/main/include/cyaml/cyaml.h)
 > in conjunction with this guide.
 
 At the top level of the YAML is a mapping with two fields, "name" and


### PR DESCRIPTION
Renaming the default branch from `master` to `main`.