### PR TITLE
Ensure C++ compatibility for designated initialisers

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -126,9 +126,9 @@ passing the `top_mapping_schema` that we defined above.
 ```c
 /* Create our CYAML configuration. */
 static const cyaml_config_t config = {
-	.log_level = CYAML_LOG_WARNING, /* Logging errors and warnings only. */
 	.log_fn = cyaml_log,            /* Use the default logging function. */
 	.mem_fn = cyaml_mem,            /* Use the default memory allocator. */
+	.log_level = CYAML_LOG_WARNING, /* Logging errors and warnings only. */
 };
 
 /* Where to store the loaded data */

--- a/examples/numerical/main.c
+++ b/examples/numerical/main.c
@@ -63,9 +63,9 @@ static const cyaml_schema_value_t top_schema = {
  * Here we have a very basic config.
  */
 static const cyaml_config_t config = {
-	.log_level = CYAML_LOG_WARNING, /* Logging errors and warnings only. */
 	.log_fn = cyaml_log,            /* Use the default logging function. */
 	.mem_fn = cyaml_mem,            /* Use the default memory allocator. */
+	.log_level = CYAML_LOG_WARNING, /* Logging errors and warnings only. */
 };
 
 /* Main entry point from OS. */

--- a/examples/planner/main.c
+++ b/examples/planner/main.c
@@ -410,9 +410,9 @@ static const cyaml_schema_value_t plan_schema = {
  * Here we have a very basic config.
  */
 static const cyaml_config_t config = {
-	.log_level = CYAML_LOG_WARNING, /* Logging errors and warnings only. */
 	.log_fn = cyaml_log,            /* Use the default logging function. */
 	.mem_fn = cyaml_mem,            /* Use the default memory allocator. */
+	.log_level = CYAML_LOG_WARNING, /* Logging errors and warnings only. */
 };
 
 /* Main entry point from OS. */

--- a/include/cyaml/cyaml.h
+++ b/include/cyaml/cyaml.h
@@ -579,11 +579,11 @@ typedef enum cyaml_err {
 		_key, _flags, _structure, _member) \
 { \
 	.key = _key, \
+	.data_offset = offsetof(_structure, _member), \
 	.value = { \
 		CYAML_VALUE_INT(((_flags) & (~CYAML_FLAG_POINTER)), \
 				(((_structure *)NULL)->_member)), \
 	}, \
-	.data_offset = offsetof(_structure, _member) \
 }
 
 /**
@@ -1099,11 +1099,11 @@ typedef enum cyaml_err {
 		_key, _flags, _structure, _member, _fields) \
 { \
 	.key = _key, \
+	.data_offset = offsetof(_structure, _member), \
 	.value = { \
 		CYAML_VALUE_MAPPING(((_flags) | CYAML_FLAG_POINTER), \
 				(*(((_structure *)NULL)->_member)), _fields), \
 	}, \
-	.data_offset = offsetof(_structure, _member) \
 }
 
 /**
@@ -1163,14 +1163,14 @@ typedef enum cyaml_err {
 		_key, _flags, _structure, _member, _entry, _min, _max) \
 { \
 	.key = _key, \
+	.data_offset = offsetof(_structure, _member), \
+	.count_offset = offsetof(_structure, _member ## _count), \
+	.count_size = sizeof(((_structure *)NULL)->_member ## _count), \
 	.value = { \
 		CYAML_VALUE_SEQUENCE((_flags), \
 				(*(((_structure *)NULL)->_member)), \
 				_entry, _min, _max), \
 	}, \
-	.data_offset = offsetof(_structure, _member), \
-	.count_size = sizeof(((_structure *)NULL)->_member ## _count), \
-	.count_offset = offsetof(_structure, _member ## _count), \
 }
 
 /**
@@ -1211,14 +1211,14 @@ typedef enum cyaml_err {
 		_key, _flags, _structure, _member, _count, _entry, _min, _max) \
 { \
 	.key = _key, \
+	.data_offset = offsetof(_structure, _member), \
+	.count_offset = offsetof(_structure, _count), \
+	.count_size = sizeof(((_structure *)NULL)->_count), \
 	.value = { \
 		CYAML_VALUE_SEQUENCE((_flags), \
 				(*(((_structure *)NULL)->_member)), \
 				_entry, _min, _max), \
 	}, \
-	.data_offset = offsetof(_structure, _member), \
-	.count_size = sizeof(((_structure *)NULL)->_count), \
-	.count_offset = offsetof(_structure, _count), \
 }
 
 /**


### PR DESCRIPTION
Resolves #166.

C++ finally has designated initialisers but they still require
member order to match the definition, even though the point of
designated initilisers is to allow you to not care about order
and be explicit about specific members' values.

Reorder the members in the schema building macros to allow
them to be used from a modern enough C++ version.