### PR TITLE
Load: Fix signed integer limit error.

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -1328,7 +1328,7 @@ static cyaml_err_t cyaml__read_int(
 		return CYAML_ERR_INVALID_DATA_SIZE;
 	}
 
-	max = (INT64_MAX >> ((8 - schema->data_size) * 8)) / 2;
+	max = (int64_t)((UINT64_MAX >> ((8 - schema->data_size) * 8)) / 2);
 	min = (-max) - 1;
 
 	errno = 0;


### PR DESCRIPTION
When loading signed integer in `cyaml__read_int()`, the `min` to `max` range is set to only half of the supposed value:
- `int8_t`: -64 to 63
- `short`: -16384 to 16383
- `int`: -2^30 to 2^30-1
- `long`: -2^62 to 2^62-1

So if the data type is `short`, a value like 20000 or -20000 in the YAML file will cause:
`libcyaml:   ERROR: Load: Invalid INT value: '20000'
`

Should use `UINT64_MAX` instead of `INT64_MAX` in the shift, like that in this pull request. Another solution is do not divide the value by 2:
`max = (INT64_MAX >> ((8 - schema->data_size) * 8));
`