### PR TITLE
Add support for default values for some of the CYAML types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,8 @@ ifeq ($(UNAME_S),Darwin)
 endif
 
 TEST_SRC_FILES = units/free.c units/load.c units/test.c units/util.c \
-		units/errs.c units/file.c units/save.c units/utf8.c
+		units/errs.c units/file.c units/save.c units/utf8.c \
+		units/load_ex.c
 TEST_SRC := $(addprefix test/,$(TEST_SRC_FILES))
 TEST_OBJ = $(patsubst %.c,%.o, $(addprefix $(BUILDDIR)/,$(TEST_SRC)))
 TEST_DEP = $(patsubst %.c,%.d, $(addprefix $(BUILDDIR)/,$(TEST_SRC)))

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ LIBYAML_CFLAGS := $(if $(PKG_CONFIG),$(shell $(PKG_CONFIG) --cflags $(LIBYAML)),
 LIBYAML_LIBS := $(if $(PKG_CONFIG),$(shell $(PKG_CONFIG) --libs $(LIBYAML)),-lyaml)
 
 INCLUDE = -I include
-CPPFLAGS += $(VERSION_FLAGS) -MMD -MP
+CPPFLAGS += $(VERSION_FLAGS) -MMD -MP -DKEEP_BOTH_VERSIONS
 CFLAGS += $(INCLUDE) $(LIBYAML_CFLAGS)
 CFLAGS += -std=c11 -Wall -Wextra -pedantic \
 		-Wconversion -Wwrite-strings -Wcast-align -Wpointer-arith \
@@ -90,7 +90,7 @@ endif
 BUILDDIR_SHARED = $(BUILDDIR)/shared
 BUILDDIR_STATIC = $(BUILDDIR)/static
 
-LIB_SRC_FILES = mem.c free.c load.c save.c util.c utf8.c
+LIB_SRC_FILES = mem.c free.c load.c save.c util.c utf8.c extended.c
 LIB_SRC := $(addprefix src/,$(LIB_SRC_FILES))
 LIB_OBJ = $(patsubst %.c,%.o, $(addprefix $(BUILDDIR)/,$(LIB_SRC)))
 LIB_DEP = $(patsubst %.c,%.d, $(addprefix $(BUILDDIR)/,$(LIB_SRC)))

--- a/include/cyaml/cyaml.h
+++ b/include/cyaml/cyaml.h
@@ -628,7 +628,8 @@ typedef enum cyaml_err {
 		_flags, _type) \
 	.type = CYAML_INT, \
 	.flags = (enum cyaml_flag)(_flags), \
-	.data_size = sizeof(_type)
+	.data_size = sizeof(_type), \
+	.string = {0}
 
 /**
  * Mapping schema helper macro for keys with \ref CYAML_INT type.
@@ -645,6 +646,8 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.data_offset = offsetof(_structure, _member), \
+	.count_offset = 0, \
+	.count_size = 0, \
 	.value = { \
 		CYAML_VALUE_INT(((_flags) & (~CYAML_FLAG_POINTER)), \
 				(((_structure *)NULL)->_member)), \
@@ -666,6 +669,8 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.data_offset = offsetof(_structure, _member), \
+	.count_offset = 0, \
+	.count_size = 0, \
 	.value = { \
 		CYAML_VALUE_INT(((_flags) | CYAML_FLAG_POINTER), \
 				(*(((_structure *)NULL)->_member))), \
@@ -682,7 +687,8 @@ typedef enum cyaml_err {
 		_flags, _type) \
 	.type = CYAML_UINT, \
 	.flags = (enum cyaml_flag)(_flags), \
-	.data_size = sizeof(_type)
+	.data_size = sizeof(_type), \
+	.string = {0}
 
 /**
  * Mapping schema helper macro for keys with \ref CYAML_UINT type.
@@ -699,6 +705,8 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.data_offset = offsetof(_structure, _member), \
+	.count_offset = 0, \
+	.count_size = 0, \
 	.value = { \
 		CYAML_VALUE_UINT(((_flags) & (~CYAML_FLAG_POINTER)), \
 				(((_structure *)NULL)->_member)), \
@@ -720,6 +728,8 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.data_offset = offsetof(_structure, _member), \
+	.count_offset = 0, \
+	.count_size = 0, \
 	.value = { \
 		CYAML_VALUE_UINT(((_flags) | CYAML_FLAG_POINTER), \
 				(*(((_structure *)NULL)->_member))), \
@@ -736,7 +746,8 @@ typedef enum cyaml_err {
 		_flags, _type) \
 	.type = CYAML_BOOL, \
 	.flags = (enum cyaml_flag)(_flags), \
-	.data_size = sizeof(_type)
+	.data_size = sizeof(_type), \
+	.string = {0}
 
 /**
  * Mapping schema helper macro for keys with \ref CYAML_BOOL type.
@@ -753,6 +764,8 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.data_offset = offsetof(_structure, _member), \
+	.count_offset = 0, \
+	.count_size = 0, \
 	.value = { \
 		CYAML_VALUE_BOOL(((_flags) & (~CYAML_FLAG_POINTER)), \
 				(((_structure *)NULL)->_member)), \
@@ -774,6 +787,8 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.data_offset = offsetof(_structure, _member), \
+	.count_offset = 0, \
+	.count_size = 0, \
 	.value = { \
 		CYAML_VALUE_BOOL(((_flags) | CYAML_FLAG_POINTER), \
 				(*(((_structure *)NULL)->_member))), \
@@ -815,6 +830,8 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.data_offset = offsetof(_structure, _member), \
+	.count_offset = 0, \
+	.count_size = 0, \
 	.value = { \
 		CYAML_VALUE_ENUM(((_flags) & (~CYAML_FLAG_POINTER)), \
 				(((_structure *)NULL)->_member), \
@@ -839,6 +856,8 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.data_offset = offsetof(_structure, _member), \
+	.count_offset = 0, \
+	.count_size = 0, \
 	.value = { \
 		CYAML_VALUE_ENUM(((_flags) | CYAML_FLAG_POINTER), \
 				(*(((_structure *)NULL)->_member)), \
@@ -881,6 +900,8 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.data_offset = offsetof(_structure, _member), \
+	.count_offset = 0, \
+	.count_size = 0, \
 	.value = { \
 		CYAML_VALUE_FLAGS(((_flags) & (~CYAML_FLAG_POINTER)), \
 				(((_structure *)NULL)->_member), \
@@ -905,6 +926,8 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.data_offset = offsetof(_structure, _member), \
+	.count_offset = 0, \
+	.count_size = 0, \
 	.value = { \
 		CYAML_VALUE_FLAGS(((_flags) | CYAML_FLAG_POINTER), \
 				(*(((_structure *)NULL)->_member)), \
@@ -947,6 +970,8 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.data_offset = offsetof(_structure, _member), \
+	.count_offset = 0, \
+	.count_size = 0, \
 	.value = { \
 		CYAML_VALUE_BITFIELD(((_flags) & (~CYAML_FLAG_POINTER)), \
 				(((_structure *)NULL)->_member), \
@@ -971,6 +996,8 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.data_offset = offsetof(_structure, _member), \
+	.count_offset = 0, \
+	.count_size = 0, \
 	.value = { \
 		CYAML_VALUE_BITFIELD(((_flags) | CYAML_FLAG_POINTER), \
 				(*(((_structure *)NULL)->_member)), \
@@ -988,7 +1015,8 @@ typedef enum cyaml_err {
 		_flags, _type) \
 	.type = CYAML_FLOAT, \
 	.flags = (enum cyaml_flag)(_flags), \
-	.data_size = sizeof(_type)
+	.data_size = sizeof(_type), \
+	.string = {0}
 
 /**
  * Mapping schema helper macro for keys with \ref CYAML_FLOAT type.
@@ -1005,6 +1033,8 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.data_offset = offsetof(_structure, _member), \
+	.count_offset = 0, \
+	.count_size = 0, \
 	.value = { \
 		CYAML_VALUE_FLOAT(((_flags) & (~CYAML_FLAG_POINTER)), \
 				(((_structure *)NULL)->_member)), \
@@ -1026,6 +1056,8 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.data_offset = offsetof(_structure, _member), \
+	.count_offset = 0, \
+	.count_size = 0, \
 	.value = { \
 		CYAML_VALUE_FLOAT(((_flags) | CYAML_FLAG_POINTER), \
 				(*(((_structure *)NULL)->_member))), \
@@ -1076,6 +1108,8 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.data_offset = offsetof(_structure, _member), \
+	.count_offset = 0, \
+	.count_size = 0, \
 	.value = { \
 		CYAML_VALUE_STRING(((_flags) & (~CYAML_FLAG_POINTER)), \
 				(((_structure *)NULL)->_member), _min, \
@@ -1104,6 +1138,8 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.data_offset = offsetof(_structure, _member), \
+	.count_offset = 0, \
+	.count_size = 0, \
 	.value = { \
 		CYAML_VALUE_STRING(((_flags) | CYAML_FLAG_POINTER), \
 				(((_structure *)NULL)->_member), \
@@ -1143,6 +1179,8 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.data_offset = offsetof(_structure, _member), \
+	.count_offset = 0, \
+	.count_size = 0, \
 	.value = { \
 		CYAML_VALUE_MAPPING(((_flags) & (~CYAML_FLAG_POINTER)), \
 				(((_structure *)NULL)->_member), _fields), \
@@ -1165,6 +1203,8 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.data_offset = offsetof(_structure, _member), \
+	.count_offset = 0, \
+	.count_size = 0, \
 	.value = { \
 		CYAML_VALUE_MAPPING(((_flags) | CYAML_FLAG_POINTER), \
 				(*(((_structure *)NULL)->_member)), _fields), \
@@ -1330,6 +1370,8 @@ typedef enum cyaml_err {
 { \
 	.key = _key, \
 	.data_offset = offsetof(_structure, _member), \
+	.count_offset = 0, \
+	.count_size = 0, \
 	.value = { \
 		CYAML_VALUE_SEQUENCE_FIXED((_flags), \
 				(*(((_structure *)NULL)->_member)), \
@@ -1347,6 +1389,9 @@ typedef enum cyaml_err {
 		_key, _flags) \
 { \
 	.key = _key, \
+	.data_offset = 0, \
+	.count_offset = 0, \
+	.count_size = 0, \
 	.value = { \
 		.type = CYAML_IGNORE, \
 		.flags = (_flags), \
@@ -1359,7 +1404,13 @@ typedef enum cyaml_err {
  * CYAML mapping schemas are formed from an array of \ref cyaml_schema_field
  * entries, and an entry with a NULL key indicates the end of the array.
  */
-#define CYAML_FIELD_END_BASE { .key = NULL }
+#define CYAML_FIELD_END_BASE { \
+	.key = NULL, \
+	.data_offset = 0, \
+	.count_offset = 0, \
+	.count_size = 0, \
+	.value = {0}, \
+}
 
 #ifndef CYAML_EX_H
 /**

--- a/include/cyaml/cyaml.h
+++ b/include/cyaml/cyaml.h
@@ -570,6 +570,8 @@ typedef enum cyaml_cfg_flags {
 	 * memory is constrained.
 	 */
 	CYAML_CFG_NO_ALIAS            = (1 << 5),
+
+	CYAML_CFG_EXTENDED            = (1 << 6),
 } cyaml_cfg_flags_t;
 
 /**
@@ -638,7 +640,7 @@ typedef enum cyaml_err {
  * \param[in]  _structure  The structure corresponding to the mapping.
  * \param[in]  _member     The member in _structure for this mapping value.
  */
-#define CYAML_FIELD_INT( \
+#define CYAML_FIELD_INT_BASE( \
 		_key, _flags, _structure, _member) \
 { \
 	.key = _key, \
@@ -659,7 +661,7 @@ typedef enum cyaml_err {
  * \param[in]  _structure  The structure corresponding to the mapping.
  * \param[in]  _member     The member in _structure for this mapping value.
  */
-#define CYAML_FIELD_INT_PTR( \
+#define CYAML_FIELD_INT_PTR_BASE( \
 		_key, _flags, _structure, _member) \
 { \
 	.key = _key, \
@@ -692,7 +694,7 @@ typedef enum cyaml_err {
  * \param[in]  _structure  The structure corresponding to the mapping.
  * \param[in]  _member     The member in _structure for this mapping value.
  */
-#define CYAML_FIELD_UINT( \
+#define CYAML_FIELD_UINT_BASE( \
 		_key, _flags, _structure, _member) \
 { \
 	.key = _key, \
@@ -713,7 +715,7 @@ typedef enum cyaml_err {
  * \param[in]  _structure  The structure corresponding to the mapping.
  * \param[in]  _member     The member in _structure for this mapping value.
  */
-#define CYAML_FIELD_UINT_PTR( \
+#define CYAML_FIELD_UINT_PTR_BASE( \
 		_key, _flags, _structure, _member) \
 { \
 	.key = _key, \
@@ -746,7 +748,7 @@ typedef enum cyaml_err {
  * \param[in]  _structure  The structure corresponding to the mapping.
  * \param[in]  _member     The member in _structure for this mapping value.
  */
-#define CYAML_FIELD_BOOL( \
+#define CYAML_FIELD_BOOL_BASE( \
 		_key, _flags, _structure, _member) \
 { \
 	.key = _key, \
@@ -767,7 +769,7 @@ typedef enum cyaml_err {
  * \param[in]  _structure  The structure corresponding to the mapping.
  * \param[in]  _member     The member in _structure for this mapping value.
  */
-#define CYAML_FIELD_BOOL_PTR( \
+#define CYAML_FIELD_BOOL_PTR_BASE( \
 		_key, _flags, _structure, _member) \
 { \
 	.key = _key, \
@@ -808,7 +810,7 @@ typedef enum cyaml_err {
  * \param[in]  _strings       Array of string data for enumeration values.
  * \param[in]  _strings_count Number of entries in _strings.
  */
-#define CYAML_FIELD_ENUM( \
+#define CYAML_FIELD_ENUM_BASE( \
 		_key, _flags, _structure, _member, _strings, _strings_count) \
 { \
 	.key = _key, \
@@ -832,7 +834,7 @@ typedef enum cyaml_err {
  * \param[in]  _strings       Array of string data for enumeration values.
  * \param[in]  _strings_count Number of entries in _strings.
  */
-#define CYAML_FIELD_ENUM_PTR( \
+#define CYAML_FIELD_ENUM_PTR_BASE( \
 		_key, _flags, _structure, _member, _strings, _strings_count) \
 { \
 	.key = _key, \
@@ -874,7 +876,7 @@ typedef enum cyaml_err {
  * \param[in]  _strings       Array of string data for flag values.
  * \param[in]  _strings_count Number of entries in _strings.
  */
-#define CYAML_FIELD_FLAGS( \
+#define CYAML_FIELD_FLAGS_BASE( \
 		_key, _flags, _structure, _member, _strings, _strings_count) \
 { \
 	.key = _key, \
@@ -898,7 +900,7 @@ typedef enum cyaml_err {
  * \param[in]  _strings       Array of string data for flag values.
  * \param[in]  _strings_count Number of entries in _strings.
  */
-#define CYAML_FIELD_FLAGS_PTR( \
+#define CYAML_FIELD_FLAGS_PTR_BASE( \
 		_key, _flags, _structure, _member, _strings, _strings_count) \
 { \
 	.key = _key, \
@@ -940,7 +942,7 @@ typedef enum cyaml_err {
  * \param[in]  _bitvals       Array of bit field value data for the bit field.
  * \param[in]  _bitvals_count Number of entries in _bitvals.
  */
-#define CYAML_FIELD_BITFIELD( \
+#define CYAML_FIELD_BITFIELD_BASE( \
 		_key, _flags, _structure, _member, _bitvals, _bitvals_count) \
 { \
 	.key = _key, \
@@ -964,7 +966,7 @@ typedef enum cyaml_err {
  * \param[in]  _bitvals       Array of bit field value data for the bit field.
  * \param[in]  _bitvals_count Number of entries in _bitvals.
  */
-#define CYAML_FIELD_BITFIELD_PTR( \
+#define CYAML_FIELD_BITFIELD_PTR_BASE( \
 		_key, _flags, _structure, _member, _bitvals, _bitvals_count) \
 { \
 	.key = _key, \
@@ -998,7 +1000,7 @@ typedef enum cyaml_err {
  * \param[in]  _structure  The structure corresponding to the mapping.
  * \param[in]  _member     The member in _structure for this mapping value.
  */
-#define CYAML_FIELD_FLOAT( \
+#define CYAML_FIELD_FLOAT_BASE( \
 		_key, _flags, _structure, _member) \
 { \
 	.key = _key, \
@@ -1019,7 +1021,7 @@ typedef enum cyaml_err {
  * \param[in]  _structure  The structure corresponding to the mapping.
  * \param[in]  _member     The member in _structure for this mapping value.
  */
-#define CYAML_FIELD_FLOAT_PTR( \
+#define CYAML_FIELD_FLOAT_PTR_BASE( \
 		_key, _flags, _structure, _member) \
 { \
 	.key = _key, \
@@ -1069,7 +1071,7 @@ typedef enum cyaml_err {
  * \param[in]  _member     The member in _structure for this mapping value.
  * \param[in]  _min        Minimum string length in bytes.  Excludes '\0'.
  */
-#define CYAML_FIELD_STRING( \
+#define CYAML_FIELD_STRING_BASE( \
 		_key, _flags, _structure, _member, _min) \
 { \
 	.key = _key, \
@@ -1097,7 +1099,7 @@ typedef enum cyaml_err {
  * \param[in]  _min        Minimum string length in bytes.  Excludes '\0'.
  * \param[in]  _max        Maximum string length in bytes.  Excludes '\0'.
  */
-#define CYAML_FIELD_STRING_PTR( \
+#define CYAML_FIELD_STRING_PTR_BASE( \
 		_key, _flags, _structure, _member, _min, _max) \
 { \
 	.key = _key, \
@@ -1116,7 +1118,7 @@ typedef enum cyaml_err {
  * \param[in]  _type          The C type of structure corresponding to mapping.
  * \param[in]  _fields        Pointer to mapping fields schema array.
  */
-#define CYAML_VALUE_MAPPING( \
+#define CYAML_VALUE_MAPPING_BASE( \
 		_flags, _type, _fields) \
 	.type = CYAML_MAPPING, \
 	.flags = (enum cyaml_flag)(_flags), \
@@ -1136,7 +1138,7 @@ typedef enum cyaml_err {
  * \param[in]  _member     The member in _structure for this mapping value.
  * \param[in]  _fields     Pointer to mapping fields schema array.
  */
-#define CYAML_FIELD_MAPPING( \
+#define CYAML_FIELD_MAPPING_BASE( \
 		_key, _flags, _structure, _member, _fields) \
 { \
 	.key = _key, \
@@ -1158,7 +1160,7 @@ typedef enum cyaml_err {
  * \param[in]  _member     The member in _structure for this mapping value.
  * \param[in]  _fields     Pointer to mapping fields schema array.
  */
-#define CYAML_FIELD_MAPPING_PTR( \
+#define CYAML_FIELD_MAPPING_PTR_BASE( \
 		_key, _flags, _structure, _member, _fields) \
 { \
 	.key = _key, \
@@ -1222,7 +1224,7 @@ typedef enum cyaml_err {
  * \param[in]  _min        Minimum number of sequence entries required.
  * \param[in]  _max        Maximum number of sequence entries required.
  */
-#define CYAML_FIELD_SEQUENCE( \
+#define CYAML_FIELD_SEQUENCE_BASE( \
 		_key, _flags, _structure, _member, _entry, _min, _max) \
 { \
 	.key = _key, \
@@ -1270,7 +1272,7 @@ typedef enum cyaml_err {
  * \param[in]  _min        Minimum number of sequence entries required.
  * \param[in]  _max        Maximum number of sequence entries required.
  */
-#define CYAML_FIELD_SEQUENCE_COUNT( \
+#define CYAML_FIELD_SEQUENCE_COUNT_BASE( \
 		_key, _flags, _structure, _member, _count, _entry, _min, _max) \
 { \
 	.key = _key, \
@@ -1323,7 +1325,7 @@ typedef enum cyaml_err {
  * \param[in]  _entry      Pointer to schema for the **entries** in sequence.
  * \param[in]  _count      Number of sequence entries required.
  */
-#define CYAML_FIELD_SEQUENCE_FIXED( \
+#define CYAML_FIELD_SEQUENCE_FIXED_BASE( \
 		_key, _flags, _structure, _member, _entry, _count) \
 { \
 	.key = _key, \
@@ -1341,7 +1343,7 @@ typedef enum cyaml_err {
  * \param[in]  _key    String defining the YAML mapping key to ignore.
  * \param[in]  _flags  Any behavioural flags relevant to this key.
  */
-#define CYAML_FIELD_IGNORE( \
+#define CYAML_FIELD_IGNORE_BASE( \
 		_key, _flags) \
 { \
 	.key = _key, \
@@ -1357,7 +1359,39 @@ typedef enum cyaml_err {
  * CYAML mapping schemas are formed from an array of \ref cyaml_schema_field
  * entries, and an entry with a NULL key indicates the end of the array.
  */
-#define CYAML_FIELD_END { .key = NULL }
+#define CYAML_FIELD_END_BASE { .key = NULL }
+
+#ifndef CYAML_EX_H
+/**
+ * Not using the expanded version of the library, so \ref cyaml_schema_field is
+ * used rather than \ref cyaml_schema_field_ex.
+ * This means the "base" version the macros should be used throughout.
+ */
+#define CYAML_FIELD_INT CYAML_FIELD_INT_BASE
+#define CYAML_FIELD_INT_PTR CYAML_FIELD_INT_PTR_BASE
+#define CYAML_FIELD_UINT CYAML_FIELD_UINT_BASE
+#define CYAML_FIELD_UINT_PTR CYAML_FIELD_UINT_PTR_BASE
+#define CYAML_FIELD_BOOL CYAML_FIELD_BOOL_BASE
+#define CYAML_FIELD_BOOL_PTR CYAML_FIELD_BOOL_PTR_BASE
+#define CYAML_FIELD_ENUM CYAML_FIELD_ENUM_BASE
+#define CYAML_FIELD_ENUM_PTR CYAML_FIELD_ENUM_PTR_BASE
+#define CYAML_FIELD_FLAGS CYAML_FIELD_FLAGS_BASE
+#define CYAML_FIELD_FLAGS_PTR CYAML_FIELD_FLAGS_PTR_BASE
+#define CYAML_FIELD_BITFIELD CYAML_FIELD_BITFIELD_BASE
+#define CYAML_FIELD_BITFIELD_PTR CYAML_FIELD_BITFIELD_PTR_BASE
+#define CYAML_FIELD_FLOAT CYAML_FIELD_FLOAT_BASE
+#define CYAML_FIELD_FLOAT_PTR CYAML_FIELD_FLOAT_PTR_BASE
+#define CYAML_FIELD_STRING CYAML_FIELD_STRING_BASE
+#define CYAML_FIELD_STRING_PTR CYAML_FIELD_STRING_PTR_BASE
+#define CYAML_VALUE_MAPPING CYAML_VALUE_MAPPING_BASE
+#define CYAML_FIELD_MAPPING CYAML_FIELD_MAPPING_BASE
+#define CYAML_FIELD_MAPPING_PTR CYAML_FIELD_MAPPING_PTR_BASE
+#define CYAML_FIELD_SEQUENCE CYAML_FIELD_SEQUENCE_BASE
+#define CYAML_FIELD_SEQUENCE_COUNT CYAML_FIELD_SEQUENCE_COUNT_BASE
+#define CYAML_FIELD_SEQUENCE_FIXED CYAML_FIELD_SEQUENCE_FIXED_BASE
+#define CYAML_FIELD_IGNORE CYAML_FIELD_IGNORE_BASE
+#define CYAML_FIELD_END CYAML_FIELD_END_BASE
+#endif
 
 /**
  * Identifies that a \ref CYAML_SEQUENCE has unconstrained maximum entry

--- a/include/cyaml/cyaml_ex.h
+++ b/include/cyaml/cyaml_ex.h
@@ -26,18 +26,6 @@ extern "C"
 #endif
 
 /**
- * Default value
- *
- * This union is used to allow specifying various default values (integers and
- * both floating point formats).
- */
-typedef union cyaml_uint_float {
-	uint64_t u64; /**< An integer default value. */
-	float f; /**< A floating-point default value. */
-	double d; /**< A double-sized floating-point default value. */
-} cyaml_uint_float_t;
-
-/**
  * Expanded schema entry for mapping fields.
  *
  * Includes the base mapping field data, and a default value (if provided).
@@ -54,9 +42,17 @@ typedef struct cyaml_schema_field_ex {
 	/**
 	 * The default value (if provided)
 	 */
-	cyaml_uint_float_t default_value;
+	union {
+		uint64_t default_value_u64; /**< An integer default value. */
+		float default_value_f; /**< A floating-point default value. */
+		double default_value_d; /**< A double-sized floating-point default value. */
+	};
 } cyaml_schema_field_ex_t;
 
+
+#define CYAML_FIELD_DEFAULT_NONE \
+	.use_default_value = false, \
+	.default_value_u64 = 0,
 
 /**
  * Expanded mapping schema helper macro for keys with \ref CYAML_INT type.
@@ -66,6 +62,7 @@ typedef struct cyaml_schema_field_ex {
 #define CYAML_FIELD_INT_EX(...) \
 { \
 	.base = CYAML_FIELD_INT_BASE(__VA_ARGS__), \
+	CYAML_FIELD_DEFAULT_NONE \
 }
 
 /**
@@ -85,8 +82,8 @@ typedef struct cyaml_schema_field_ex {
 { \
 	.base = CYAML_FIELD_INT_BASE(_key, (_flags | CYAML_FLAG_OPTIONAL), \
 			__VA_ARGS__), \
-	.default_value.u64 = (uint64_t)_default, \
 	.use_default_value = true, \
+	.default_value_u64 = (uint64_t)_default, \
 }
 
 /**
@@ -97,6 +94,7 @@ typedef struct cyaml_schema_field_ex {
 #define CYAML_FIELD_INT_PTR_EX(...) \
 { \
 	.base = CYAML_FIELD_INT_PTR_BASE(__VA_ARGS__), \
+	CYAML_FIELD_DEFAULT_NONE \
 }
 
 /**
@@ -107,6 +105,7 @@ typedef struct cyaml_schema_field_ex {
 #define CYAML_FIELD_UINT_EX(...) \
 { \
 	.base = CYAML_FIELD_UINT_BASE(__VA_ARGS__), \
+	CYAML_FIELD_DEFAULT_NONE \
 }
 
 /**
@@ -127,8 +126,8 @@ typedef struct cyaml_schema_field_ex {
 { \
 	.base = CYAML_FIELD_UINT_BASE(_key, (_flags | CYAML_FLAG_OPTIONAL), \
 			__VA_ARGS__), \
-	.default_value.u64 = (uint64_t)_default, \
 	.use_default_value = true, \
+	.default_value_u64 = (uint64_t)_default, \
 }
 
 /**
@@ -139,6 +138,7 @@ typedef struct cyaml_schema_field_ex {
 #define CYAML_FIELD_UINT_PTR_EX(...) \
 { \
 	.base = CYAML_FIELD_UINT_PTR_BASE(__VA_ARGS__), \
+	CYAML_FIELD_DEFAULT_NONE \
 }
 
 /**
@@ -149,6 +149,7 @@ typedef struct cyaml_schema_field_ex {
 #define CYAML_FIELD_BOOL_EX(...) \
 { \
 	.base = CYAML_FIELD_BOOL_BASE(__VA_ARGS__), \
+	CYAML_FIELD_DEFAULT_NONE \
 }
 
 /**
@@ -169,8 +170,8 @@ typedef struct cyaml_schema_field_ex {
 { \
 	.base = CYAML_FIELD_BOOL_BASE(_key, (_flags | CYAML_FLAG_OPTIONAL), \
 			__VA_ARGS__), \
-	.default_value.u64 = (uint64_t)_default, \
 	.use_default_value = true, \
+	.default_value_u64 = (uint64_t)_default, \
 }
 
 /**
@@ -181,6 +182,7 @@ typedef struct cyaml_schema_field_ex {
 #define CYAML_FIELD_BOOL_PTR_EX(...) \
 { \
 	.base = CYAML_FIELD_BOOL_PTR_BASE(__VA_ARGS__), \
+	CYAML_FIELD_DEFAULT_NONE \
 }
 
 /**
@@ -191,6 +193,7 @@ typedef struct cyaml_schema_field_ex {
 #define CYAML_FIELD_ENUM_EX(...) \
 { \
 	.base = CYAML_FIELD_ENUM_BASE(__VA_ARGS__), \
+	CYAML_FIELD_DEFAULT_NONE \
 }
 
 /**
@@ -213,8 +216,8 @@ typedef struct cyaml_schema_field_ex {
 { \
 	.base = CYAML_FIELD_ENUM_BASE(_key, (_flags | CYAML_FLAG_OPTIONAL), \
 			__VA_ARGS__), \
-	.default_value.u64 = (uint64_t)_default, \
 	.use_default_value = true, \
+	.default_value_u64 = (uint64_t)_default, \
 }
 
 /**
@@ -225,6 +228,7 @@ typedef struct cyaml_schema_field_ex {
 #define CYAML_FIELD_ENUM_PTR_EX(...) \
 { \
 	.base = CYAML_FIELD_ENUM_PTR_BASE(__VA_ARGS__), \
+	CYAML_FIELD_DEFAULT_NONE \
 }
 
 /**
@@ -235,6 +239,7 @@ typedef struct cyaml_schema_field_ex {
 #define CYAML_FIELD_FLAGS_EX(...) \
 { \
 	.base = CYAML_FIELD_FLAGS_BASE(__VA_ARGS__), \
+	CYAML_FIELD_DEFAULT_NONE \
 }
 
 /**
@@ -257,8 +262,8 @@ typedef struct cyaml_schema_field_ex {
 { \
 	.base = CYAML_FIELD_FLAGS_BASE(_key, (_flags | CYAML_FLAG_OPTIONAL), \
 			__VA_ARGS__), \
-	.default_value.u64 = _default, \
 	.use_default_value = true, \
+	.default_value_u64 = _default, \
 }
 
 /**
@@ -269,6 +274,7 @@ typedef struct cyaml_schema_field_ex {
 #define CYAML_FIELD_FLAGS_PTR_EX(...) \
 { \
 	.base = CYAML_FIELD_FLAGS_PTR_BASE(__VA_ARGS__), \
+	CYAML_FIELD_DEFAULT_NONE \
 }
 
 /**
@@ -279,6 +285,7 @@ typedef struct cyaml_schema_field_ex {
 #define CYAML_FIELD_BITFIELD_EX(...) \
 { \
 	.base = CYAML_FIELD_BITFIELD_BASE(__VA_ARGS__), \
+	CYAML_FIELD_DEFAULT_NONE \
 }
 
 /**
@@ -301,8 +308,8 @@ typedef struct cyaml_schema_field_ex {
 { \
 	.base = CYAML_FIELD_BITFIELD_BASE(_key, \
 			(_flags | CYAML_FLAG_OPTIONAL), __VA_ARGS__), \
-	.default_value.u64 = (uint64_t)_default, \
 	.use_default_value = true, \
+	.default_value_u64 = (uint64_t)_default, \
 }
 
 /**
@@ -313,6 +320,7 @@ typedef struct cyaml_schema_field_ex {
 #define CYAML_FIELD_BITFIELD_PTR_EX(...) \
 { \
 	.base = CYAML_FIELD_BITFIELD_PTR_BASE(__VA_ARGS__), \
+	CYAML_FIELD_DEFAULT_NONE \
 }
 
 /**
@@ -323,6 +331,7 @@ typedef struct cyaml_schema_field_ex {
 #define CYAML_FIELD_FLOAT_EX(...) \
 { \
 	.base = CYAML_FIELD_FLOAT_BASE(__VA_ARGS__), \
+	CYAML_FIELD_DEFAULT_NONE \
 }
 
 /**
@@ -343,8 +352,8 @@ typedef struct cyaml_schema_field_ex {
 { \
 	.base = CYAML_FIELD_FLOAT_BASE(_key, (_flags | CYAML_FLAG_OPTIONAL), \
 			_structure, _member), \
-	.default_value.f = (float)_default, \
 	.use_default_value = true, \
+	.default_value_f = (float)_default, \
 }
 
 /**
@@ -365,8 +374,8 @@ typedef struct cyaml_schema_field_ex {
 { \
 	.base = CYAML_FIELD_FLOAT_BASE(_key, (_flags | CYAML_FLAG_OPTIONAL), \
 			_structure, _member), \
-	.default_value.d = (double)_default, \
 	.use_default_value = true, \
+	.default_value_d = (double)_default, \
 }
 
 /**
@@ -377,6 +386,7 @@ typedef struct cyaml_schema_field_ex {
 #define CYAML_FIELD_FLOAT_PTR_EX(...) \
 { \
 	.base = CYAML_FIELD_FLOAT_PTR_BASE(__VA_ARGS__), \
+	CYAML_FIELD_DEFAULT_NONE \
 }
 
 /**
@@ -387,6 +397,7 @@ typedef struct cyaml_schema_field_ex {
 #define CYAML_FIELD_STRING_EX(...) \
 { \
 	.base = CYAML_FIELD_STRING_BASE(__VA_ARGS__), \
+	CYAML_FIELD_DEFAULT_NONE \
 }
 
 /**
@@ -397,6 +408,7 @@ typedef struct cyaml_schema_field_ex {
 #define CYAML_FIELD_STRING_PTR_EX(...) \
 { \
 	.base = CYAML_FIELD_STRING_PTR_BASE(__VA_ARGS__), \
+	CYAML_FIELD_DEFAULT_NONE \
 }
 
 /**
@@ -419,6 +431,7 @@ typedef struct cyaml_schema_field_ex {
 #define CYAML_FIELD_MAPPING_EX(...) \
 { \
 	.base = CYAML_FIELD_MAPPING_BASE(__VA_ARGS__), \
+	CYAML_FIELD_DEFAULT_NONE \
 }
 
 /**
@@ -429,6 +442,7 @@ typedef struct cyaml_schema_field_ex {
 #define CYAML_FIELD_MAPPING_PTR_EX(...) \
 { \
 	.base = CYAML_FIELD_MAPPING_PTR_BASE(__VA_ARGS__), \
+	CYAML_FIELD_DEFAULT_NONE \
 }
 
 /**
@@ -439,6 +453,7 @@ typedef struct cyaml_schema_field_ex {
 #define CYAML_FIELD_SEQUENCE_EX(...) \
 { \
 	.base = CYAML_FIELD_SEQUENCE_BASE(__VA_ARGS__), \
+	CYAML_FIELD_DEFAULT_NONE \
 }
 
 /**
@@ -449,6 +464,7 @@ typedef struct cyaml_schema_field_ex {
 #define CYAML_FIELD_SEQUENCE_PTR_EX(...) \
 { \
 	.base = CYAML_FIELD_SEQUENCE_PTR_BASE(__VA_ARGS__), \
+	CYAML_FIELD_DEFAULT_NONE \
 }
 
 /**
@@ -459,6 +475,7 @@ typedef struct cyaml_schema_field_ex {
 #define CYAML_FIELD_SEQUENCE_COUNT_EX(...) \
 { \
 	.base = CYAML_FIELD_SEQUENCE_COUNT_BASE(__VA_ARGS__), \
+	CYAML_FIELD_DEFAULT_NONE \
 }
 
 /**
@@ -470,6 +487,7 @@ typedef struct cyaml_schema_field_ex {
 #define CYAML_FIELD_SEQUENCE_FIXED_EX(...) \
 { \
 	.base = CYAML_FIELD_SEQUENCE_FIXED_BASE(__VA_ARGS__), \
+	CYAML_FIELD_DEFAULT_NONE \
 }
 
 /**
@@ -480,6 +498,7 @@ typedef struct cyaml_schema_field_ex {
 #define CYAML_FIELD_IGNORE_EX(...) \
 { \
 	.base = CYAML_FIELD_IGNORE_BASE(__VA_ARGS__), \
+	CYAML_FIELD_DEFAULT_NONE \
 }
 
 /**
@@ -488,7 +507,10 @@ typedef struct cyaml_schema_field_ex {
  *
  * Similar to /ref CYAML_FIELD_END.
  */
-#define CYAML_FIELD_END_EX { .base = CYAML_FIELD_END_BASE }
+#define CYAML_FIELD_END_EX { \
+	.base = CYAML_FIELD_END_BASE, \
+	CYAML_FIELD_DEFAULT_NONE \
+}
 
 /**
  * Load a YAML document from a file at the given path, using expanded cyaml

--- a/include/cyaml/cyaml_ex.h
+++ b/include/cyaml/cyaml_ex.h
@@ -1,0 +1,606 @@
+#ifndef CYAML_EX_H
+#define CYAML_EX_H
+
+#include <stdbool.h>
+
+#if defined(CYAML_H) && !defined(KEEP_BOTH_VERSIONS)
+#error "cyaml_ex.h must be included before cyaml.h"
+#endif
+
+#ifdef KEEP_BOTH_VERSIONS
+#include "cyaml.h"
+#define cyaml_schema_field_base cyaml_schema_field
+#else
+#define cyaml_schema_field cyaml_schema_field_base
+#define cyaml_schema_field_t cyaml_schema_field_base_t
+#include "cyaml.h"
+#undef cyaml_schema_field_t
+#undef cyaml_schema_field
+#define cyaml_schema_field cyaml_schema_field_ex
+#define cyaml_schema_field_t cyaml_schema_field_ex_t
+#endif
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * Default value
+ *
+ * This union is used to allow specifying various default values (integers and
+ * both floating point formats).
+ */
+typedef union cyaml_uint_float {
+	uint64_t u64; /**< An integer default value. */
+	float f; /**< A floating-point default value. */
+	double d; /**< A double-sized floating-point default value. */
+} cyaml_uint_float_t;
+
+/**
+ * Expanded schema entry for mapping fields.
+ *
+ * Includes the base mapping field data, and a default value (if provided).
+ */
+typedef struct cyaml_schema_field_ex {
+	/**
+	 * The base schema mapping field data
+	 */
+	struct cyaml_schema_field_base base;
+	/**
+	 * Set if a default value is provided for this field
+	 */
+	bool use_default_value;
+	/**
+	 * The default value (if provided)
+	 */
+	cyaml_uint_float_t default_value;
+} cyaml_schema_field_ex_t;
+
+
+/**
+ * Expanded mapping schema helper macro for keys with \ref CYAML_INT type.
+ *
+ * Similar to \ref CYAML_FIELD_INT_BASE.
+ */
+#define CYAML_FIELD_INT_EX(...) \
+{ \
+	.base = CYAML_FIELD_INT_BASE(__VA_ARGS__), \
+}
+
+/**
+ * Mapping schema helper macro for keys with \ref CYAML_INT type with a default
+ * value.
+ *
+ * Use this for integers contained in structs. Based on \ref CYAML_FIELD_INT.
+ *
+ * \param[in]  _default    Value to be set as a default when loading.
+ * \param[in]  _key        String defining the YAML mapping key for this value.
+ * \param[in]  _flags      Any behavioural flags relevant to this value.
+ * \param[in]  _structure  The structure corresponding to the mapping.
+ * \param[in]  _member     The member in _structure for this mapping value.
+ */
+#define CYAML_FIELD_INT_DEFAULT( \
+	_default, _key, _flags, ...) \
+{ \
+	.base = CYAML_FIELD_INT_BASE(_key, (_flags | CYAML_FLAG_OPTIONAL), \
+			__VA_ARGS__), \
+	.default_value.u64 = (uint64_t)_default, \
+	.use_default_value = true, \
+}
+
+/**
+ * Expanded mapping schema helper macro for keys with \ref CYAML_INT type.
+ *
+ * Similar to \ref CYAML_FIELD_INT_PTR.
+ */
+#define CYAML_FIELD_INT_PTR_EX(...) \
+{ \
+	.base = CYAML_FIELD_INT_PTR_BASE(__VA_ARGS__), \
+}
+
+/**
+ * Expanded mapping schema helper macro for keys with \ref CYAML_UINT type.
+ *
+ * Similar to \ref CYAML_FIELD_UINT.
+ */
+#define CYAML_FIELD_UINT_EX(...) \
+{ \
+	.base = CYAML_FIELD_UINT_BASE(__VA_ARGS__), \
+}
+
+/**
+ * Value schema helper macro for keys with \ref CYAML_UINT type with a default
+ * value.
+ *
+ * Use this for unsigned integers contained in structs. Based on
+ * \ref CYAML_FIELD_UINT
+ *
+ * \param[in]  _default    Value to be set as a default when loading.
+ * \param[in]  _key        String defining the YAML mapping key for this value.
+ * \param[in]  _flags      Any behavioural flags relevant to this value.
+ * \param[in]  _structure  The structure corresponding to the mapping.
+ * \param[in]  _member     The member in _structure for this mapping value.
+ */
+#define CYAML_FIELD_UINT_DEFAULT( \
+		_default, _key, _flags, ...) \
+{ \
+	.base = CYAML_FIELD_UINT_BASE(_key, (_flags | CYAML_FLAG_OPTIONAL), \
+			__VA_ARGS__), \
+	.default_value.u64 = (uint64_t)_default, \
+	.use_default_value = true, \
+}
+
+/**
+ * Expanded mapping schema helper macro for keys with \ref CYAML_UINT type.
+ *
+ * Similar to \ref CYAML_FIELD_UINT_PTR.
+ */
+#define CYAML_FIELD_UINT_PTR_EX(...) \
+{ \
+	.base = CYAML_FIELD_UINT_PTR_BASE(__VA_ARGS__), \
+}
+
+/**
+ * Expanded mapping schema helper macro for keys with \ref CYAML_BOOL type.
+ *
+ * Similar to \ref CYAML_FIELD_BOOL.
+ */
+#define CYAML_FIELD_BOOL_EX(...) \
+{ \
+	.base = CYAML_FIELD_BOOL_BASE(__VA_ARGS__), \
+}
+
+/**
+ * Value schema helper macro for keys with \ref CYAML_BOOL type with a default
+ * value.
+ *
+ * Use this for boolean types contained in structs. Based on
+ * \ref CYAML_FIELD_BOOL
+ *
+ * \param[in]  _default    Value to be set as a default when loading.
+ * \param[in]  _key        String defining the YAML mapping key for this value.
+ * \param[in]  _flags      Any behavioural flags relevant to this value.
+ * \param[in]  _structure  The structure corresponding to the mapping.
+ * \param[in]  _member     The member in _structure for this mapping value.
+ */
+#define CYAML_FIELD_BOOL_DEFAULT( \
+		_default, _key, _flags, ...) \
+{ \
+	.base = CYAML_FIELD_BOOL_BASE(_key, (_flags | CYAML_FLAG_OPTIONAL), \
+			__VA_ARGS__), \
+	.default_value.u64 = (uint64_t)_default, \
+	.use_default_value = true, \
+}
+
+/**
+ * Expanded mapping schema helper macro for keys with \ref CYAML_BOOL type.
+ *
+ * Similar to \ref CYAML_FIELD_BOOL_PTR.
+ */
+#define CYAML_FIELD_BOOL_PTR_EX(...) \
+{ \
+	.base = CYAML_FIELD_BOOL_PTR_BASE(__VA_ARGS__), \
+}
+
+/**
+ * Expanded mapping schema helper macro for keys with \ref CYAML_ENUM type.
+ *
+ * Similar to \ref CYAML_FIELD_ENUM.
+ */
+#define CYAML_FIELD_ENUM_EX(...) \
+{ \
+	.base = CYAML_FIELD_ENUM_BASE(__VA_ARGS__), \
+}
+
+/**
+ * Mapping schema helper macro for keys with \ref CYAML_ENUM type with a default
+ * value.
+ *
+ * Use this for enumerated types contained in structs. Based on
+ * \ref CYAML_FIELD_ENUM.
+ *
+ * \param[in]  _default    Value to be set as a default when loading.
+ * \param[in]  _key        String defining the YAML mapping key for this value.
+ * \param[in]  _flags      Any behavioural flags relevant to this value.
+ * \param[in]  _structure  The structure corresponding to the mapping.
+ * \param[in]  _member     The member in _structure for this mapping value.
+ * \param[in]  _strings       Array of string data for enumeration values.
+ * \param[in]  _strings_count Number of entries in _strings.
+ */
+#define CYAML_FIELD_ENUM_DEFAULT( \
+		_default, _key, _flags, ...) \
+{ \
+	.base = CYAML_FIELD_ENUM_BASE(_key, (_flags | CYAML_FLAG_OPTIONAL), \
+			__VA_ARGS__), \
+	.default_value.u64 = (uint64_t)_default, \
+	.use_default_value = true, \
+}
+
+/**
+ * Expanded mapping schema helper macro for keys with \ref CYAML_ENUM type.
+ *
+ * Similar to \ref CYAML_FIELD_ENUM_PTR.
+ */
+#define CYAML_FIELD_ENUM_PTR_EX(...) \
+{ \
+	.base = CYAML_FIELD_ENUM_PTR_BASE(__VA_ARGS__), \
+}
+
+/**
+ * Expanded mapping schema helper macro for keys with \ref CYAML_FLAGS type.
+ *
+ * Similar to \ref CYAML_FIELD_FLAGS.
+ */
+#define CYAML_FIELD_FLAGS_EX(...) \
+{ \
+	.base = CYAML_FIELD_FLAGS_BASE(__VA_ARGS__), \
+}
+
+/**
+ * Mapping schema helper macro for keys with \ref CYAML_FLAGS type with a
+ * default value.
+ *
+ * Use this for flag types contained in structs. Based on
+ * \ref CYAML_FIELD_FLAGS.
+ *
+ * \param[in]  _default    Value to be set as a default when loading.
+ * \param[in]  _key        String defining the YAML mapping key for this value.
+ * \param[in]  _flags      Any behavioural flags relevant to this value.
+ * \param[in]  _structure  The structure corresponding to the mapping.
+ * \param[in]  _member     The member in _structure for this mapping value.
+ * \param[in]  _strings       Array of string data for flag values.
+ * \param[in]  _strings_count Number of entries in _strings.
+ */
+#define CYAML_FIELD_FLAGS_DEFAULT( \
+		_default, _key, _flags, ...) \
+{ \
+	.base = CYAML_FIELD_FLAGS_BASE(_key, (_flags | CYAML_FLAG_OPTIONAL), \
+			__VA_ARGS__), \
+	.default_value.u64 = _default, \
+	.use_default_value = true, \
+}
+
+/**
+ * Expanded mapping schema helper macro for keys with \ref CYAML_FLAGS type.
+ *
+ * Similar to \ref CYAML_FIELD_FLAGS_PTR.
+ */
+#define CYAML_FIELD_FLAGS_PTR_EX(...) \
+{ \
+	.base = CYAML_FIELD_FLAGS_PTR_BASE(__VA_ARGS__), \
+}
+
+/**
+ * Expanded mapping schema helper macro for keys with \ref CYAML_BITFIELD type.
+ *
+ * Similar to \ref CYAML_FIELD_BITFIELD.
+ */
+#define CYAML_FIELD_BITFIELD_EX(...) \
+{ \
+	.base = CYAML_FIELD_BITFIELD_BASE(__VA_ARGS__), \
+}
+
+/**
+ * Mapping schema helper macro for keys with \ref CYAML_BITFIELD type with a
+ * default value.
+ *
+ * Use this for bit field types contained in structs. Based on
+ * \ref CYAML_FIELD_BITFIELD.
+ *
+ * \param[in]  _default    Value to be set as a default when loading.
+ * \param[in]  _key        String defining the YAML mapping key for this value.
+ * \param[in]  _flags      Any behavioural flags relevant to this value.
+ * \param[in]  _structure  The structure corresponding to the mapping.
+ * \param[in]  _member     The member in _structure for this mapping value.
+ * \param[in]  _bitvals       Array of bit field value data for the bit field.
+ * \param[in]  _bitvals_count Number of entries in _bitvals.
+ */
+#define CYAML_FIELD_BITFIELD_DEFAULT( \
+		_default, _key, _flags, ...) \
+{ \
+	.base = CYAML_FIELD_BITFIELD_BASE(_key, \
+			(_flags | CYAML_FLAG_OPTIONAL), __VA_ARGS__), \
+	.default_value.u64 = (uint64_t)_default, \
+	.use_default_value = true, \
+}
+
+/**
+ * Expanded mapping schema helper macro for keys with \ref CYAML_BITFIELD type.
+ *
+ * Similar to \ref CYAML_FIELD_BITFIELD_PTR.
+ */
+#define CYAML_FIELD_BITFIELD_PTR_EX(...) \
+{ \
+	.base = CYAML_FIELD_BITFIELD_PTR_BASE(__VA_ARGS__), \
+}
+
+/**
+ * Expanded mapping schema helper macro for keys with \ref CYAML_FLOAT type.
+ *
+ * Similar to \ref CYAML_FIELD_FLOAT.
+ */
+#define CYAML_FIELD_FLOAT_EX(...) \
+{ \
+	.base = CYAML_FIELD_FLOAT_BASE(__VA_ARGS__), \
+}
+
+/**
+ * Mapping schema helper macro for keys with \ref CYAML_FLOAT type with a
+ * default floating-point value.
+ *
+ * Use this for floating point types contained in structs. Based on
+ * \ref CYAML_FIELD_FLOAT.
+ *
+ * \param[in]  _default    Value to be set as a default when loading.
+ * \param[in]  _key        String defining the YAML mapping key for this value.
+ * \param[in]  _flags      Any behavioural flags relevant to this value.
+ * \param[in]  _structure  The structure corresponding to the mapping.
+ * \param[in]  _member     The member in _structure for this mapping value.
+ */
+#define CYAML_FIELD_FLOAT_DEFAULT( \
+		_default, _key, _flags, _structure, _member) \
+{ \
+	.base = CYAML_FIELD_FLOAT_BASE(_key, (_flags | CYAML_FLAG_OPTIONAL), \
+			_structure, _member), \
+	.default_value.f = (float)_default, \
+	.use_default_value = true, \
+}
+
+/**
+ * Mapping schema helper macro for keys with \ref CYAML_FLOAT type with a
+ * default double-sized floating-point value.
+ *
+ * Use this for double-sized floating point types contained in structs. Based on
+ * \ref CYAML_FIELD_FLOAT.
+ *
+ * \param[in]  _default    Value to be set as a default when loading.
+ * \param[in]  _key        String defining the YAML mapping key for this value.
+ * \param[in]  _flags      Any behavioural flags relevant to this value.
+ * \param[in]  _structure  The structure corresponding to the mapping.
+ * \param[in]  _member     The member in _structure for this mapping value.
+ */
+#define CYAML_FIELD_DOUBLE_DEFAULT( \
+		_default, _key, _flags, _structure, _member) \
+{ \
+	.base = CYAML_FIELD_FLOAT_BASE(_key, (_flags | CYAML_FLAG_OPTIONAL), \
+			_structure, _member), \
+	.default_value.d = (double)_default, \
+	.use_default_value = true, \
+}
+
+/**
+ * Exapnded apping schema helper macro for keys with \ref CYAML_FLOAT type.
+ *
+ * Similar to \ref CYAML_FIELD_FLOAT.
+ */
+#define CYAML_FIELD_FLOAT_PTR_EX(...) \
+{ \
+	.base = CYAML_FIELD_FLOAT_PTR_BASE(__VA_ARGS__), \
+}
+
+/**
+ * Expanded mapping schema helper macro for keys with \ref CYAML_STRING type.
+ *
+ * Similar to \ref CYAML_FIELD_STRING.
+ */
+#define CYAML_FIELD_STRING_EX(...) \
+{ \
+	.base = CYAML_FIELD_STRING_BASE(__VA_ARGS__), \
+}
+
+/**
+ * Expanded mapping schema helper macro for keys with \ref CYAML_STRING type.
+ *
+ * Similar to \ref CYAML_FIELD_STRING_PTR.
+ */
+#define CYAML_FIELD_STRING_PTR_EX(...) \
+{ \
+	.base = CYAML_FIELD_STRING_PTR_BASE(__VA_ARGS__), \
+}
+
+/**
+ * Value schema helper macro for values with \ref CYAML_MAPPING type, when
+ * the fields allow for default values.
+ *
+ * \param[in]  _flags         Any behavioural flags relevant to this value.
+ * \param[in]  _type          The C type of structure corresponding to mapping.
+ * \param[in]  _fields        Pointer to mapping fields schema array.
+ */
+#define CYAML_VALUE_MAPPING_EX( \
+		_flags, _type, _fields) \
+	CYAML_VALUE_MAPPING_BASE(_flags, _type, &_fields[0].base)
+
+/**
+ * Expanded mapping schema helper macro for keys with \ref CYAML_MAPPING type.
+ *
+ * Similar to /ref CYAML_FIELD_MAPPING.
+ */
+#define CYAML_FIELD_MAPPING_EX(...) \
+{ \
+	.base = CYAML_FIELD_MAPPING_BASE(__VA_ARGS__), \
+}
+
+/**
+ * Expanded mapping schema helper macro for keys with \ref CYAML_MAPPING type.
+ *
+ * Similar to /ref CYAML_FIELD_MAPPING.
+ */
+#define CYAML_FIELD_MAPPING_PTR_EX(...) \
+{ \
+	.base = CYAML_FIELD_MAPPING_PTR_BASE(__VA_ARGS__), \
+}
+
+/**
+ * Expanded mapping schema helper macro for keys with \ref CYAML_SEQUENCE type.
+ *
+ * Similar to /ref CYAML_FIELD_SEQUENCE.
+ */
+#define CYAML_FIELD_SEQUENCE_EX(...) \
+{ \
+	.base = CYAML_FIELD_SEQUENCE_BASE(__VA_ARGS__), \
+}
+
+/**
+ * Expanded mapping schema helper macro for keys with \ref CYAML_SEQUENCE type.
+ *
+ * Similar to /ref CYAML_FIELD_SEQUENCE_PTR.
+ */
+#define CYAML_FIELD_SEQUENCE_PTR_EX(...) \
+{ \
+	.base = CYAML_FIELD_SEQUENCE_PTR_BASE(__VA_ARGS__), \
+}
+
+/**
+ * Expanded mapping schema helper macro for keys with \ref CYAML_SEQUENCE type.
+ *
+ * Similar to /ref CYAML_FIELD_SEQUENCE_COUNT.
+ */
+#define CYAML_FIELD_SEQUENCE_COUNT_EX(...) \
+{ \
+	.base = CYAML_FIELD_SEQUENCE_COUNT_BASE(__VA_ARGS__), \
+}
+
+/**
+ * Expanded mapping schema helper macro for keys with \ref CYAML_SEQUENCE_FIXED
+ * type.
+ *
+ * Similar to /ref CYAML_FIELD_SEQUENCE_FIXED.
+ */
+#define CYAML_FIELD_SEQUENCE_FIXED_EX(...) \
+{ \
+	.base = CYAML_FIELD_SEQUENCE_FIXED_BASE(__VA_ARGS__), \
+}
+
+/**
+ * Mapping schema helper macro for keys with \ref CYAML_IGNORE type.
+ *
+ * Similar to /ref CYAML_FIELD_IGNORE.
+ */
+#define CYAML_FIELD_IGNORE_EX(...) \
+{ \
+	.base = CYAML_FIELD_IGNORE_BASE(__VA_ARGS__), \
+}
+
+/**
+ * Expanded mapping schema helper macro for terminating an array of mapping
+ * fields.
+ *
+ * Similar to /ref CYAML_FIELD_END.
+ */
+#define CYAML_FIELD_END_EX { .base = CYAML_FIELD_END_BASE }
+
+/**
+ * Load a YAML document from a file at the given path, using expanded cyaml
+ * field structures.
+ *
+ * Similar to \ref cyaml_load_file, but will set up the expanded library flag by
+ * default.
+ */
+extern cyaml_err_t cyaml_load_file_ex(
+		const char *path,
+		const cyaml_config_t *config,
+		const cyaml_schema_value_t *schema,
+		cyaml_data_t **data_out,
+		unsigned *seq_count_out);
+
+/**
+ * Load a YAML document from a data buffer, using expanded cyaml field
+ * structures.
+ *
+ * Similar to \ref cyaml_load_data, but will set up the expanded library flag by
+ * default.
+ */
+extern cyaml_err_t cyaml_load_data_ex(
+		const uint8_t *input,
+		size_t input_len,
+		const cyaml_config_t *config,
+		const cyaml_schema_value_t *schema,
+		cyaml_data_t **data_out,
+		unsigned *seq_count_out);
+
+/**
+ * Save a YAML document to a file at the given path, using expanded cyaml field
+ * structures.
+ *
+ * Similar to \ref cyaml_save_file, but will set up the expanded library flag by
+ * default.
+ */
+extern cyaml_err_t cyaml_save_file_ex(
+		const char *path,
+		const cyaml_config_t *config,
+		const cyaml_schema_value_t *schema,
+		const cyaml_data_t *data,
+		unsigned seq_count);
+
+/**
+ * Save a YAML document into a string in memory, using expanded cyaml field
+ * structures.
+ *
+ * Similar to \ref cyaml_save_data, but will set up the expanded library flag by
+ * default.
+ */
+extern cyaml_err_t cyaml_save_data_ex(
+		char **output,
+		size_t *len,
+		const cyaml_config_t *config,
+		const cyaml_schema_value_t *schema,
+		const cyaml_data_t *data,
+		unsigned seq_count);
+
+/**
+ * Free data returned by a CYAML load function, using expanded cyaml field
+ * structures.
+ *
+ * Similar to \ref cyaml_free, but will set up the expanded library flag by
+ * default.
+ */
+extern cyaml_err_t cyaml_free_ex(
+		const cyaml_config_t *config,
+		const cyaml_schema_value_t *schema,
+		cyaml_data_t *data,
+		unsigned seq_count);
+
+#ifndef KEEP_BOTH_VERSIONS
+#define CYAML_FIELD_INT CYAML_FIELD_INT_EX
+#define CYAML_FIELD_INT_PTR CYAML_FIELD_INT_PTR_EX
+#define CYAML_FIELD_UINT CYAML_FIELD_UINT_EX
+#define CYAML_FIELD_UINT_PTR CYAML_FIELD_UINT_PTR_EX
+#define CYAML_FIELD_BOOL CYAML_FIELD_BOOL_EX
+#define CYAML_FIELD_BOOL_PTR CYAML_FIELD_BOOL_PTR_EX
+#define CYAML_FIELD_ENUM CYAML_FIELD_ENUM_EX
+#define CYAML_FIELD_ENUM_PTR CYAML_FIELD_ENUM_PTR_EX
+#define CYAML_FIELD_FLAGS CYAML_FIELD_FLAGS_EX
+#define CYAML_FIELD_FLAGS_PTR CYAML_FIELD_FLAGS_PTR_EX
+#define CYAML_FIELD_BITFIELD CYAML_FIELD_BITFIELD_EX
+#define CYAML_FIELD_BITFIELD_PTR CYAML_FIELD_BITFIELD_PTR_EX
+#define CYAML_FIELD_FLOAT CYAML_FIELD_FLOAT_EX
+#define CYAML_FIELD_FLOAT_PTR CYAML_FIELD_FLOAT_PTR_EX
+#define CYAML_FIELD_STRING CYAML_FIELD_STRING_EX
+#define CYAML_FIELD_STRING_PTR CYAML_FIELD_STRING_PTR_EX
+#define CYAML_VALUE_MAPPING CYAML_VALUE_MAPPING_EX
+#define CYAML_FIELD_MAPPING CYAML_FIELD_MAPPING_EX
+#define CYAML_FIELD_MAPPING_PTR CYAML_FIELD_MAPPING_PTR_EX
+#define CYAML_FIELD_SEQUENCE CYAML_FIELD_SEQUENCE_EX
+#define CYAML_FIELD_SEQUENCE_PTR CYAML_FIELD_SEQUENCE_PTR_EX
+#define CYAML_FIELD_SEQUENCE_COUNT CYAML_FIELD_SEQUENCE_COUNT_EX
+#define CYAML_FIELD_SEQUENCE_FIXED CYAML_FIELD_SEQUENCE_FIXED_EX
+#define CYAML_FIELD_IGNORE CYAML_FIELD_IGNORE_EX
+#define CYAML_FIELD_END CYAML_FIELD_END_EX
+#undef cyaml_load_file
+#define cyaml_load_file cyaml_load_file_ex
+#undef cyaml_load_data
+#define cyaml_load_data cyaml_load_data_ex
+#undef cyaml_save_file
+#define cyaml_save_file cyaml_save_file_ex
+#undef cyaml_save_data
+#define cyaml_save_data cyaml_save_data_ex
+#undef cymal_free
+#define cymal_free cymal_free_ex
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/data.h
+++ b/src/data.h
@@ -12,7 +12,7 @@
 #ifndef CYAML_DATA_H
 #define CYAML_DATA_H
 
-#include "cyaml/cyaml.h"
+#include "cyaml/cyaml_ex.h"
 #include "util.h"
 
 /**

--- a/src/extended.c
+++ b/src/extended.c
@@ -1,0 +1,80 @@
+#include <stdbool.h>
+#include <assert.h>
+
+#include "data.h"
+
+static void cyaml__update_config(
+	const cyaml_config_t *config,
+	cyaml_config_t *config_copy)
+{
+	*config_copy = *config;
+	config_copy->flags |= CYAML_CFG_EXTENDED;
+}
+
+cyaml_err_t cyaml_load_file_ex(
+		const char *path,
+		const cyaml_config_t *config,
+		const cyaml_schema_value_t *schema,
+		cyaml_data_t **data_out,
+		unsigned *seq_count_out)
+{
+	cyaml_config_t cfg_copy;
+
+	cyaml__update_config(config, &cfg_copy);
+	return cyaml_load_file(path, &cfg_copy, schema, data_out,
+			seq_count_out);
+}
+
+cyaml_err_t cyaml_load_data_ex(
+		const uint8_t *input,
+		size_t input_len,
+		const cyaml_config_t *config,
+		const cyaml_schema_value_t *schema,
+		cyaml_data_t **data_out,
+		unsigned *seq_count_out)
+{
+	cyaml_config_t cfg_copy;
+
+	cyaml__update_config(config, &cfg_copy);
+	return cyaml_load_data(input, input_len, &cfg_copy, schema, data_out,
+			seq_count_out);
+}
+
+cyaml_err_t cyaml_save_file_ex(
+		const char *path,
+		const cyaml_config_t *config,
+		const cyaml_schema_value_t *schema,
+		const cyaml_data_t *data,
+		unsigned seq_count)
+{
+	cyaml_config_t cfg_copy;
+
+	cyaml__update_config(config, &cfg_copy);
+	return cyaml_save_file(path, &cfg_copy, schema, data, seq_count);
+}
+
+cyaml_err_t cyaml_save_data_ex(
+		char **output,
+		size_t *len,
+		const cyaml_config_t *config,
+		const cyaml_schema_value_t *schema,
+		const cyaml_data_t *data,
+		unsigned seq_count)
+{
+	cyaml_config_t cfg_copy;
+
+	cyaml__update_config(config, &cfg_copy);
+	return cyaml_save_data(output, len, &cfg_copy, schema, data, seq_count);
+}
+
+cyaml_err_t cyaml_free_ex(
+		const cyaml_config_t *config,
+		const cyaml_schema_value_t *schema,
+		cyaml_data_t *data,
+		unsigned seq_count)
+{
+	cyaml_config_t cfg_copy;
+
+	cyaml__update_config(config, &cfg_copy);
+	return cyaml_free(&cfg_copy, schema, data, seq_count);
+}

--- a/src/load.c
+++ b/src/load.c
@@ -1234,9 +1234,9 @@ static void cyaml__set_default_value(
 			break;
 
 		if (field->base.value.data_size == 4)
-			default_value = &field->default_value.f;
+			default_value = &field->default_value_f;
 		else
-			default_value = &field->default_value.d;
+			default_value = &field->default_value_d;
 
 		memcpy(value_data, default_value, field->base.value.data_size);
 		break;
@@ -1244,7 +1244,7 @@ static void cyaml__set_default_value(
 		if (!field->use_default_value)
 			break;
 
-		cyaml_data_write(field->default_value.u64,
+		cyaml_data_write(field->default_value_u64,
 				field->base.value.data_size, value_data);
 		break;
 	}

--- a/src/load.c
+++ b/src/load.c
@@ -21,11 +21,8 @@
 #include <float.h>
 #include <math.h>
 
-#include <yaml.h>
-
 #include "mem.h"
 #include "data.h"
-#include "util.h"
 
 /** Identifies that no mapping schema entry was found for key. */
 #define CYAML_FIELDS_IDX_NONE 0xffff

--- a/src/mem.h
+++ b/src/mem.h
@@ -14,7 +14,7 @@
 
 #include <string.h>
 
-#include "cyaml/cyaml.h"
+#include "cyaml/cyaml_ex.h"
 
 /**
  * Helper for freeing using the client's choice of allocator routine.

--- a/src/mem.h
+++ b/src/mem.h
@@ -12,6 +12,8 @@
 #ifndef CYAML_MEM_H
 #define CYAML_MEM_H
 
+#include <string.h>
+
 #include "cyaml/cyaml.h"
 
 /**

--- a/src/save.c
+++ b/src/save.c
@@ -17,10 +17,8 @@
 #include <assert.h>
 #include <limits.h>
 
-#include <yaml.h>
-
-#include "mem.h"
 #include "data.h"
+#include "mem.h"
 #include "util.h"
 
 /**

--- a/src/util.h
+++ b/src/util.h
@@ -15,7 +15,7 @@
 #include <string.h>
 #include <yaml.h>
 
-#include "cyaml/cyaml.h"
+#include "cyaml/cyaml_ex.h"
 #include "utf8.h"
 
 /** Macro to squash unused variable compiler warnings. */

--- a/src/util.h
+++ b/src/util.h
@@ -12,6 +12,9 @@
 #ifndef CYAML_UTIL_H
 #define CYAML_UTIL_H
 
+#include <string.h>
+#include <yaml.h>
+
 #include "cyaml/cyaml.h"
 #include "utf8.h"
 

--- a/test/units/load_ex.c
+++ b/test/units/load_ex.c
@@ -1,0 +1,464 @@
+#include <inttypes.h>
+#include <stdbool.h>
+#include <assert.h>
+
+#include <cyaml/cyaml_ex.h>
+
+#include "../../src/data.h"
+#include "ttest.h"
+#include "test.h"
+
+/**
+ * Unit test context data.
+ */
+typedef struct test_data {
+	cyaml_data_t **data;
+	unsigned *seq_count;
+	const struct cyaml_config *config;
+	const struct cyaml_schema_value *schema;
+} test_data_t;
+
+/** Helper macro to count bytes of YAML input data. */
+#define YAML_LEN(_y) (sizeof(_y) - 1)
+
+/**
+ * Common clean up function to free data loaded by tests.
+ *
+ * \param[in]  data  The unit test context data.
+ */
+static void cyaml_cleanup(void *data)
+{
+	struct test_data *td = data;
+	unsigned seq_count = 0;
+
+	if (td->seq_count != NULL) {
+		seq_count = *(td->seq_count);
+	}
+
+	if (td->data != NULL) {
+		cyaml_free(td->config, td->schema, *(td->data), seq_count);
+	}
+}
+
+/**
+ * Test loading a positive signed integer.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_ex_mapping_entry_int_pos(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	static const int value = 90;
+	static const unsigned char yaml[] =
+		"test_int: 90\n";
+	struct target_struct {
+		int test_value_int;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field_ex mapping_schema[] = {
+		CYAML_FIELD_INT_EX("test_int", CYAML_FLAG_DEFAULT,
+				struct target_struct, test_value_int),
+		CYAML_FIELD_END_EX
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING_EX(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+	ttest_ctx_t tc;
+
+	if (!ttest_start(report, __func__, cyaml_cleanup, &td, &tc)) {
+		return true;
+	}
+
+	err = cyaml_load_data_ex(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (data_tgt->test_value_int != value) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test default of a positive signed integer.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_ex_mapping_entry_int_pos_default(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	static const int value = 90, default_value = 50;
+	static const unsigned char yaml[] =
+		"test_int: 90\n";
+	struct target_struct {
+		int test_value_int;
+		int test_value_here;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field_ex mapping_schema[] = {
+		CYAML_FIELD_INT_DEFAULT(default_value, "not_here",
+				CYAML_FLAG_DEFAULT, struct target_struct,
+				test_value_here),
+		CYAML_FIELD_INT_EX("test_int", CYAML_FLAG_DEFAULT,
+				struct target_struct, test_value_int),
+		CYAML_FIELD_END_EX
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING_EX(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+	ttest_ctx_t tc;
+
+	if (!ttest_start(report, __func__, cyaml_cleanup, &td, &tc)) {
+		return true;
+	}
+
+	err = cyaml_load_data_ex(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (data_tgt->test_value_int != value) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+	if (data_tgt->test_value_here != default_value) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test default for an enumeration.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_ex_mapping_entry_enum_default(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	static const enum test_enum {
+		TEST_ENUM_FIRST,
+		TEST_ENUM_SECOND,
+		TEST_ENUM_THIRD,
+		TEST_ENUM__COUNT,
+	} value = TEST_ENUM_SECOND, default_value = TEST_ENUM_THIRD;
+	static const cyaml_strval_t strings[TEST_ENUM__COUNT] = {
+		[TEST_ENUM_FIRST]  = { "first",  0 },
+		[TEST_ENUM_SECOND] = { "second", 1 },
+		[TEST_ENUM_THIRD]  = { "third",  2 },
+	};
+	static const unsigned char yaml[] =
+		"test_enum: second\n";
+	struct target_struct {
+		enum test_enum test_value_enum;
+		enum test_enum default_value_enum;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field_ex mapping_schema[] = {
+		CYAML_FIELD_ENUM_EX("test_enum", CYAML_FLAG_DEFAULT,
+				struct target_struct, test_value_enum,
+				strings, TEST_ENUM__COUNT),
+		CYAML_FIELD_ENUM_DEFAULT(default_value, "test_def_enum",
+				CYAML_FLAG_DEFAULT, struct target_struct,
+				default_value_enum, strings, TEST_ENUM__COUNT),
+		CYAML_FIELD_END_EX
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING_EX(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+	ttest_ctx_t tc;
+
+	if (!ttest_start(report, __func__, cyaml_cleanup, &td, &tc)) {
+		return true;
+	}
+
+	err = cyaml_load_data_ex(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (data_tgt->test_value_enum != value) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+	if (data_tgt->default_value_enum != default_value) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test default floating point value.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_ex_mapping_entry_float_default(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	static const float value = 3.14159f, def_value = 2.71828f;
+	static const unsigned char yaml[] =
+		"test_fp: 3.14159\n";
+	struct target_struct {
+		float test_value_fp;
+		float test_def_value_fp;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field_ex mapping_schema[] = {
+		CYAML_FIELD_FLOAT_EX("test_fp", CYAML_FLAG_DEFAULT,
+				struct target_struct, test_value_fp),
+		CYAML_FIELD_FLOAT_DEFAULT(def_value, "def_test_fp",
+				CYAML_FLAG_DEFAULT, struct target_struct,
+				test_def_value_fp),
+		CYAML_FIELD_END_EX
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING_EX(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+	ttest_ctx_t tc;
+
+	if (!ttest_start(report, __func__, cyaml_cleanup, &td, &tc)) {
+		return true;
+	}
+
+	err = cyaml_load_data_ex(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (data_tgt->test_value_fp != value) {
+		return ttest_fail(&tc, "Incorrect value: "
+				"expected: %f, got: %f",
+				value, data_tgt->test_value_fp);
+	}
+	if (data_tgt->test_def_value_fp != def_value) {
+		return ttest_fail(&tc, "Incorrect value: "
+				"expected: %f, got: %f",
+				def_value, data_tgt->test_def_value_fp);
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test default floating point value as a double.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_ex_mapping_entry_double_default(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	static const double value = 3.14159, def_value = 2.71828;
+	static const unsigned char yaml[] =
+		"test_fp: 3.14159\n";
+	struct target_struct {
+		double test_value_fp;
+		double test_def_value_fp;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field_ex mapping_schema[] = {
+		CYAML_FIELD_FLOAT_EX("test_fp", CYAML_FLAG_DEFAULT,
+				struct target_struct, test_value_fp),
+		CYAML_FIELD_DOUBLE_DEFAULT(def_value, "def_test_fp",
+				CYAML_FLAG_DEFAULT, struct target_struct,
+				test_def_value_fp),
+		CYAML_FIELD_END_EX
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING_EX(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+	ttest_ctx_t tc;
+
+	if (!ttest_start(report, __func__, cyaml_cleanup, &td, &tc)) {
+		return true;
+	}
+
+	err = cyaml_load_data_ex(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (data_tgt->test_value_fp != value) {
+		return ttest_fail(&tc, "Incorrect value: "
+				"expected: %lf, got: %lf",
+				value, data_tgt->test_value_fp);
+	}
+	if (data_tgt->test_def_value_fp != def_value) {
+		return ttest_fail(&tc, "Incorrect value: "
+				"expected: %lf, got: %lf",
+				def_value, data_tgt->test_def_value_fp);
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test default of a positive signed integer.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_ex_sequence_with_default_int(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	static const int default_value = 50;
+	static const unsigned char yaml[] =
+		"test:\n"
+		"- test_int: 100\n"
+		"- test_int: 70\n"
+		"  default_int: 20\n"
+		"- test_int: 90\n";
+	struct target_entry {
+		int test_value_int;
+		int test_value_here;
+	};
+	struct target_struct {
+		struct target_entry *entries;
+		uint8_t entries_count;
+	};
+	struct target_struct *data_tgt = NULL;
+	struct target_entry expected[] = {
+		{ 100, default_value },
+		{ 70, 20 },
+		{ 90, default_value },
+	};
+	static const struct cyaml_schema_field_ex mapping_entry[] = {
+		CYAML_FIELD_INT_DEFAULT(default_value, "default_int",
+				CYAML_FLAG_DEFAULT, struct target_entry,
+				test_value_here),
+		CYAML_FIELD_INT_EX("test_int", CYAML_FLAG_DEFAULT,
+				struct target_entry, test_value_int),
+		CYAML_FIELD_END_EX
+	};
+	static const struct cyaml_schema_value mapping_entry_schema = {
+		CYAML_VALUE_MAPPING_EX(CYAML_FLAG_DEFAULT, struct target_entry,
+				mapping_entry),
+	};
+	static const struct cyaml_schema_field_ex mapping_schema[] = {
+		CYAML_FIELD_SEQUENCE_EX("test", CYAML_FLAG_POINTER,
+				struct target_struct, entries,
+				&mapping_entry_schema, 0, CYAML_UNLIMITED),
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING_EX(CYAML_FLAG_POINTER, struct target_struct,
+				mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+	ttest_ctx_t tc;
+
+	if (!ttest_start(report, __func__, cyaml_cleanup, &td, &tc)) {
+		return true;
+	}
+
+	err = cyaml_load_data_ex(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (data_tgt->entries_count != CYAML_ARRAY_LEN(expected)) {
+		return ttest_fail(&tc, "Incorrect number of entries");
+	}
+	for (unsigned i = 0; i < data_tgt->entries_count; i++) {
+		if (data_tgt->entries[i].test_value_int !=
+		    expected[i].test_value_int) {
+			return ttest_fail(&tc, "Incorrect value");
+		}
+		if (data_tgt->entries[i].test_value_here !=
+		    expected[i].test_value_here) {
+			return ttest_fail(&tc, "Incorrect value");
+		}
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Run the YAML loading unit tests.
+ *
+ * \param[in]  rc         The ttest report context.
+ * \param[in]  log_level  CYAML log level.
+ * \param[in]  log_fn     CYAML logging function, or NULL.
+ * \return true iff all unit tests pass, otherwise false.
+ */
+bool load_ex_tests(
+		ttest_report_ctx_t *rc,
+		cyaml_log_t log_level,
+		cyaml_log_fn_t log_fn)
+{
+	bool pass = true;
+	cyaml_config_t config = {
+		.log_fn = log_fn,
+		.mem_fn = cyaml_mem,
+		.log_level = log_level,
+		.flags = CYAML_CFG_DEFAULT | CYAML_CFG_EXTENDED,
+	};
+
+	ttest_heading(rc, "Load single entry mapping tests (extended): simple types");
+
+	pass &= test_load_ex_mapping_entry_int_pos(rc, &config);
+	pass &= test_load_ex_mapping_entry_int_pos_default(rc, &config);
+	pass &= test_load_ex_mapping_entry_enum_default(rc, &config);
+	pass &= test_load_ex_mapping_entry_float_default(rc, &config);
+	pass &= test_load_ex_mapping_entry_double_default(rc, &config);
+	pass &= test_load_ex_sequence_with_default_int(rc, &config);
+
+	return pass;
+}

--- a/test/units/test.c
+++ b/test/units/test.c
@@ -78,6 +78,7 @@ int main(int argc, char *argv[])
 	pass &= errs_tests(&rc, log_level, log_fn);
 	pass &= file_tests(&rc, log_level, log_fn);
 	pass &= save_tests(&rc, log_level, log_fn);
+	pass &= load_ex_tests(&rc, log_level, log_fn);
 
 	ttest_report(&rc);
 

--- a/test/units/test.h
+++ b/test/units/test.h
@@ -49,4 +49,10 @@ extern bool save_tests(
 		cyaml_log_t log_level,
 		cyaml_log_fn_t log_fn);
 
+/** In load_ex.c */
+extern bool load_ex_tests(
+		ttest_report_ctx_t *rc,
+		cyaml_log_t log_level,
+		cyaml_log_fn_t log_fn);
+
 #endif

--- a/test/units/util.c
+++ b/test/units/util.c
@@ -9,8 +9,6 @@
 #include <string.h>
 #include <stdio.h>
 
-#include <cyaml/cyaml.h>
-
 #include "../../src/mem.h"
 #include "../../src/util.h"
 


### PR DESCRIPTION
* Support default values (with new macros) for integer, float, boolean, enum and bitfield fields
* Can work with code compiled without those updates without rebuilding said code
* Existing code can be updated to allow default values support simply by including "cyaml_ex.h" instead of "cyaml.h"
* Some new tests for the new functionality