### PR TITLE
Load: API: Add CYAML_CFG_IGNORED_KEY_WARNING flag

### DIFF
--- a/include/cyaml/cyaml.h
+++ b/include/cyaml/cyaml.h
@@ -570,6 +570,10 @@ typedef enum cyaml_cfg_flags {
 	 * memory is constrained.
 	 */
 	CYAML_CFG_NO_ALIAS            = (1 << 5),
+	/**
+	 * Log any ignored mapping keys at \ref CYAML_LOG_WARNING level.
+	 */
+	CYAML_CFG_IGNORED_KEY_WARNING = (1 << 6),
 } cyaml_cfg_flags_t;
 
 /**

--- a/src/load.c
+++ b/src/load.c
@@ -2286,7 +2286,6 @@ static cyaml_err_t cyaml__map_key(
 	if (ctx->state->mapping.fields_idx == CYAML_FIELDS_IDX_NONE) {
 		const yaml_event_t *const ignore_event =
 				cyaml__current_event(ctx);
-		cyaml_event_t cyaml_event;
 		if (!(ctx->config->flags &
 				CYAML_CFG_IGNORE_UNKNOWN_KEYS)) {
 			cyaml__log(ctx->config, CYAML_LOG_ERROR,
@@ -2299,8 +2298,9 @@ static cyaml_err_t cyaml__map_key(
 		if (err != CYAML_OK) {
 			return err;
 		}
-		cyaml_event = cyaml__get_event_type(ignore_event);
-		return cyaml__consume_ignored_value(ctx, cyaml_event);
+
+		return cyaml__consume_ignored_value(ctx,
+				cyaml__get_event_type(ignore_event));
 	}
 
 	err = cyaml__map_key_check_field(ctx);

--- a/src/load.c
+++ b/src/load.c
@@ -2237,6 +2237,22 @@ static cyaml_err_t cyaml__doc_end(
 }
 
 /**
+ * Log an ignored mapping key.
+ *
+ * \param[in]  ctx  The CYAML loading context.
+ * \param[in]  key  The key that has been ignored.
+ */
+static inline void cyaml__log_ignored_key(
+		const cyaml_ctx_t *ctx,
+		const char *key)
+{
+	cyaml_log_t lvl = ctx->config->flags & CYAML_CFG_IGNORED_KEY_WARNING ?
+			CYAML_LOG_WARNING : CYAML_LOG_DEBUG;
+
+	cyaml__log(ctx->config, lvl, "Load: Ignoring value for key: %s\n", key);
+}
+
+/**
  * Check the field against the schema for the current mapping key.
  *
  * \param[in]  ctx  The CYAML loading context.
@@ -2256,6 +2272,8 @@ static cyaml_err_t cyaml__map_key_check_field(
 					field->key);
 			return CYAML_ERR_UNEXPECTED_EVENT;
 		}
+	} else {
+		cyaml__log_ignored_key(ctx, field->key);
 	}
 
 	cyaml__mapping_bitfieid_set(ctx);
@@ -2291,8 +2309,9 @@ static cyaml_err_t cyaml__map_key(
 					"Load: Unexpected key: %s\n", key);
 			return CYAML_ERR_INVALID_KEY;
 		}
-		cyaml__log(ctx->config, CYAML_LOG_DEBUG,
-				"Load: Ignoring key: %s\n", key);
+
+		cyaml__log_ignored_key(ctx, key);
+
 		err = cyaml_get_next_event(ctx);
 		if (err != CYAML_OK) {
 			return err;

--- a/src/load.c
+++ b/src/load.c
@@ -2286,8 +2286,7 @@ static cyaml_err_t cyaml__map_key(
 	if (ctx->state->mapping.fields_idx == CYAML_FIELDS_IDX_NONE) {
 		const yaml_event_t *const ignore_event =
 				cyaml__current_event(ctx);
-		if (!(ctx->config->flags &
-				CYAML_CFG_IGNORE_UNKNOWN_KEYS)) {
+		if (!(ctx->config->flags & CYAML_CFG_IGNORE_UNKNOWN_KEYS)) {
 			cyaml__log(ctx->config, CYAML_LOG_ERROR,
 					"Load: Unexpected key: %s\n", key);
 			return CYAML_ERR_INVALID_KEY;

--- a/test/units/load.c
+++ b/test/units/load.c
@@ -3514,7 +3514,7 @@ static bool test_load_mapping_entry_sequence_ptr_string_ptr(
 	static const struct cyaml_schema_field mapping_schema[] = {
 		CYAML_FIELD_SEQUENCE("sequence", CYAML_FLAG_POINTER,
 				struct target_struct, seq, &entry_schema,
-				0, CYAML_ARRAY_LEN(ref)),
+				0, CYAML_UNLIMITED),
 		CYAML_FIELD_END
 	};
 	static const struct cyaml_schema_value top_schema = {


### PR DESCRIPTION
When this flag is set, LibCYAML will warn whenever a mapping key is
encountered that is ignored, either explicitly by the CYAML_IGNORE
type or implicitly by the CYAML_CFG_IGNORE_UNKNOWN_KEYS config setting.