### PR TITLE
Allow schema to define integer range constraints

### DIFF
--- a/include/cyaml/cyaml.h
+++ b/include/cyaml/cyaml.h
@@ -388,6 +388,26 @@ typedef struct cyaml_schema_value {
 		/** \ref CYAML_INT type-specific schema data. */
 		struct {
 			/**
+			 * Minimum allowed value.
+			 *
+			 * Setting `INT64_MIN` is equivalent to having no
+			 * minimum constraint.
+			 *
+			 * \note If both `min` and `max` are set to zero,
+			 *       no range constraint is applied.
+			 */
+			int64_t min;
+			/**
+			 * Maximum allowed value.
+			 *
+			 * Setting `INT64_MAX` is equivalent to having no
+			 * maximum constraint.
+			 *
+			 * \note If both `min` and `max` are set to zero,
+			 *       no range constraint is applied.
+			 */
+			int64_t max;
+			/**
 			 * Value to use for missing YAML field.
 			 *
 			 * This is only used when the value is used for a
@@ -398,6 +418,26 @@ typedef struct cyaml_schema_value {
 		} integer;
 		/** \ref CYAML_UINT type-specific schema data. */
 		struct {
+			/**
+			 * Minimum allowed value.
+			 *
+			 * Setting `0` is equivalent to having no minimum
+			 * constraint.
+			 *
+			 * \note If both `min` and `max` are set to zero,
+			 *       no range constraint is applied.
+			 */
+			uint64_t min;
+			/**
+			 * Maximum allowed value.
+			 *
+			 * Setting `UINT64_MAX` is equivalent to having no
+			 * maximum constraint.
+			 *
+			 * \note If both `min` and `max` are set to zero,
+			 *       no range constraint is applied.
+			 */
+			uint64_t max;
 			/**
 			 * Value to use for missing YAML field.
 			 *

--- a/src/load.c
+++ b/src/load.c
@@ -1670,6 +1670,39 @@ static void cyaml__backtrace(
 }
 
 /**
+ * Check that \ref CYAML_INT value within range mandated by the value's schema.
+ *
+ * \param[in]  ctx     The CYAML loading context.
+ * \param[in]  schema  The schema for the value.
+ * \param[in]  value   The value to check.
+ * \return \ref CYAML_OK on success, or appropriate error code otherwise.
+ */
+static inline cyaml_err_t cyaml__validate_range_constraint_int(
+		const cyaml_ctx_t *ctx,
+		const cyaml_schema_value_t *schema,
+		int64_t value)
+{
+	int64_t min = schema->integer.min;
+	int64_t max = schema->integer.max;
+
+	assert(schema->type == CYAML_INT);
+
+	if (min == 0 && max == 0) {
+		return CYAML_OK;
+	}
+
+	if (value < min || value > max) {
+		cyaml__log(ctx->config, CYAML_LOG_ERROR,
+				"Load: INT value '%" PRIi64 "' out of range "
+				"(min: %" PRIi64 " max: % " PRIi64 ")\n",
+				value, min, max);
+		return CYAML_ERR_INVALID_VALUE;
+	}
+
+	return CYAML_OK;
+}
+
+/**
  * Read a value of type \ref CYAML_INT.
  *
  * \param[in]  ctx     The CYAML loading context.
@@ -1695,6 +1728,15 @@ static cyaml_err_t cyaml__read_int(
 				"Load: Invalid INT value: '%s'\n",
 				value);
 		return CYAML_ERR_INVALID_VALUE;
+	}
+
+	if (schema->type == CYAML_INT) {
+		cyaml_err_t err;
+
+		err = cyaml__validate_range_constraint_int(ctx, schema, temp);
+		if (err != CYAML_OK) {
+			return err;
+		}
 	}
 
 	return cyaml__store_int(ctx, schema, (int64_t)temp, data);
@@ -1731,6 +1773,39 @@ static inline cyaml_err_t cyaml__read_uint64_t(
 }
 
 /**
+ * Check that \ref CYAML_UINT value within range mandated by the value's schema.
+ *
+ * \param[in]  ctx     The CYAML loading context.
+ * \param[in]  schema  The schema for the value.
+ * \param[in]  value   The value to check.
+ * \return \ref CYAML_OK on success, or appropriate error code otherwise.
+ */
+static inline cyaml_err_t cyaml__validate_range_constraint_uint(
+		const cyaml_ctx_t *ctx,
+		const cyaml_schema_value_t *schema,
+		uint64_t value)
+{
+	uint64_t min = schema->unsigned_integer.min;
+	uint64_t max = schema->unsigned_integer.max;
+
+	assert(schema->type == CYAML_UINT);
+
+	if (min == 0 && max == 0) {
+		return CYAML_OK;
+	}
+
+	if (value < min || value > max) {
+		cyaml__log(ctx->config, CYAML_LOG_ERROR,
+				"Load: UINT value '%" PRIu64 "' out of range "
+				"(min: %" PRIu64 " max: % " PRIu64 ")\n",
+				value, min, max);
+		return CYAML_ERR_INVALID_VALUE;
+	}
+
+	return CYAML_OK;
+}
+
+/**
  * Read a value of type \ref CYAML_UINT.
  *
  * \param[in]  ctx     The CYAML loading context.
@@ -1751,6 +1826,13 @@ static cyaml_err_t cyaml__read_uint(
 	err = cyaml__read_uint64_t(ctx, value, &temp);
 	if (err != CYAML_OK) {
 		return err;
+	}
+
+	if (schema->type == CYAML_UINT) {
+		err = cyaml__validate_range_constraint_uint(ctx, schema, temp);
+		if (err != CYAML_OK) {
+			return err;
+		}
 	}
 
 	return cyaml__store_uint(ctx, schema, temp, data);

--- a/test/units/errs.c
+++ b/test/units/errs.c
@@ -5333,6 +5333,202 @@ static bool test_err_load_schema_invalid_value_int64_limit_pos(
 }
 
 /**
+ * Test loading a positive signed integer with a range constraint.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_err_load_schema_invalid_value_range_int_1(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	static const unsigned char yaml[] =
+		"test: 90\n";
+	struct target_struct {
+		int test;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD(INT, "test", CYAML_FLAG_DEFAULT,
+				struct target_struct, test, {
+					.min = -16,
+					.max =  64,
+				}),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+	ttest_ctx_t tc;
+
+	if (!ttest_start(report, __func__, cyaml_cleanup, &td, &tc)) {
+		return true;
+	}
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_ERR_INVALID_VALUE) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading a negative signed integer with a range constraint.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_err_load_schema_invalid_value_range_int_2(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	static const unsigned char yaml[] =
+		"test: -9000\n";
+	struct target_struct {
+		int test;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD(INT, "test", CYAML_FLAG_DEFAULT,
+				struct target_struct, test, {
+					.min = -16,
+					.max =  64,
+				}),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+	ttest_ctx_t tc;
+
+	if (!ttest_start(report, __func__, cyaml_cleanup, &td, &tc)) {
+		return true;
+	}
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_ERR_INVALID_VALUE) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading an unsigned integer with a range constraint.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_err_load_schema_invalid_value_range_uint_1(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	static const unsigned char yaml[] =
+		"test: 10\n";
+	struct target_struct {
+		unsigned test;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD(UINT, "test", CYAML_FLAG_DEFAULT,
+				struct target_struct, test, {
+					.min =  50,
+					.max = 100,
+				}),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+	ttest_ctx_t tc;
+
+	if (!ttest_start(report, __func__, cyaml_cleanup, &td, &tc)) {
+		return true;
+	}
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_ERR_INVALID_VALUE) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading an unsigned integer with a range constraint.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_err_load_schema_invalid_value_range_uint_2(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	static const unsigned char yaml[] =
+		"test: 200\n";
+	struct target_struct {
+		unsigned test;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD(UINT, "test", CYAML_FLAG_DEFAULT,
+				struct target_struct, test, {
+					.min =  50,
+					.max = 100,
+				}),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+	ttest_ctx_t tc;
+
+	if (!ttest_start(report, __func__, cyaml_cleanup, &td, &tc)) {
+		return true;
+	}
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_ERR_INVALID_VALUE) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
  * Test loading when schema expects string, but it's too short.
  *
  * \param[in]  report  The test report context.
@@ -8503,6 +8699,13 @@ bool errs_tests(
 	pass &= test_err_load_schema_invalid_value_int32_limit_pos(rc, &config);
 	pass &= test_err_load_schema_invalid_value_int64_limit_neg(rc, &config);
 	pass &= test_err_load_schema_invalid_value_int64_limit_pos(rc, &config);
+
+	ttest_heading(rc, "YAML / schema mismatch: Integer range constraints");
+
+	pass &= test_err_load_schema_invalid_value_range_int_1(rc, &config);
+	pass &= test_err_load_schema_invalid_value_range_int_2(rc, &config);
+	pass &= test_err_load_schema_invalid_value_range_uint_1(rc, &config);
+	pass &= test_err_load_schema_invalid_value_range_uint_2(rc, &config);
 
 	ttest_heading(rc, "YAML / schema mismatch: string lengths");
 

--- a/test/units/load.c
+++ b/test/units/load.c
@@ -10449,6 +10449,384 @@ static bool test_load_anchor_updated_anchor(
 }
 
 /**
+ * Test loading a positive signed integer with a range constraint.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_mapping_field_range_int_1(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	int test = 90;
+	static const unsigned char yaml[] =
+		"test: 90\n";
+	struct target_struct {
+		int test;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD(INT, "test", CYAML_FLAG_DEFAULT,
+				struct target_struct, test, {
+					.min = INT64_MIN,
+					.max = INT64_MAX,
+				}),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+	ttest_ctx_t tc;
+
+	if (!ttest_start(report, __func__, cyaml_cleanup, &td, &tc)) {
+		return true;
+	}
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (data_tgt->test != test) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading a negative signed integer with a range constraint.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_mapping_field_range_int_2(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	int test = -9000;
+	static const unsigned char yaml[] =
+		"test: -9000\n";
+	struct target_struct {
+		int test;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD(INT, "test", CYAML_FLAG_DEFAULT,
+				struct target_struct, test, {
+					.min = INT64_MIN,
+					.max = INT64_MAX,
+				}),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+	ttest_ctx_t tc;
+
+	if (!ttest_start(report, __func__, cyaml_cleanup, &td, &tc)) {
+		return true;
+	}
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (data_tgt->test != test) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading a negative signed integer with a range constraint.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_mapping_field_range_int_3(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	int test = -9000;
+	static const unsigned char yaml[] =
+		"test: -9000\n";
+	struct target_struct {
+		int test;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD(INT, "test", CYAML_FLAG_DEFAULT,
+				struct target_struct, test, {
+					.min = INT64_MIN,
+					.max = 0,
+				}),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+	ttest_ctx_t tc;
+
+	if (!ttest_start(report, __func__, cyaml_cleanup, &td, &tc)) {
+		return true;
+	}
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (data_tgt->test != test) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading a positive signed integer with a range constraint.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_mapping_field_range_int_4(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	int test = 1000000;
+	static const unsigned char yaml[] =
+		"test: 1000000\n";
+	struct target_struct {
+		int test;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD(INT, "test", CYAML_FLAG_DEFAULT,
+				struct target_struct, test, {
+					.min = 0,
+					.max = 9999999,
+				}),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+	ttest_ctx_t tc;
+
+	if (!ttest_start(report, __func__, cyaml_cleanup, &td, &tc)) {
+		return true;
+	}
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (data_tgt->test != test) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading an unsigned integer with a range constraint.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_mapping_field_range_uint_1(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	unsigned test = 90;
+	static const unsigned char yaml[] =
+		"test: 90\n";
+	struct target_struct {
+		unsigned test;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD(UINT, "test", CYAML_FLAG_DEFAULT,
+				struct target_struct, test, {
+					.min = 0,
+					.max = UINT64_MAX,
+				}),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+	ttest_ctx_t tc;
+
+	if (!ttest_start(report, __func__, cyaml_cleanup, &td, &tc)) {
+		return true;
+	}
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (data_tgt->test != test) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading an unsigned integer with a range constraint.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_mapping_field_range_uint_2(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	unsigned test = 90;
+	static const unsigned char yaml[] =
+		"test: 90\n";
+	struct target_struct {
+		unsigned test;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD(UINT, "test", CYAML_FLAG_DEFAULT,
+				struct target_struct, test, {
+					.min = 50,
+					.max = UINT64_MAX,
+				}),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+	ttest_ctx_t tc;
+
+	if (!ttest_start(report, __func__, cyaml_cleanup, &td, &tc)) {
+		return true;
+	}
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (data_tgt->test != test) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
+ * Test loading an unsigned integer with a range constraint.
+ *
+ * \param[in]  report  The test report context.
+ * \param[in]  config  The CYAML config to use for the test.
+ * \return true if test passes, false otherwise.
+ */
+static bool test_load_mapping_field_range_uint_3(
+		ttest_report_ctx_t *report,
+		const cyaml_config_t *config)
+{
+	unsigned test = 90;
+	static const unsigned char yaml[] =
+		"test: 90\n";
+	struct target_struct {
+		unsigned test;
+	} *data_tgt = NULL;
+	static const struct cyaml_schema_field mapping_schema[] = {
+		CYAML_FIELD(UINT, "test", CYAML_FLAG_DEFAULT,
+				struct target_struct, test, {
+					.min =  50,
+					.max = 100,
+				}),
+		CYAML_FIELD_END
+	};
+	static const struct cyaml_schema_value top_schema = {
+		CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+				struct target_struct, mapping_schema),
+	};
+	test_data_t td = {
+		.data = (cyaml_data_t **) &data_tgt,
+		.config = config,
+		.schema = &top_schema,
+	};
+	cyaml_err_t err;
+	ttest_ctx_t tc;
+
+	if (!ttest_start(report, __func__, cyaml_cleanup, &td, &tc)) {
+		return true;
+	}
+
+	err = cyaml_load_data(yaml, YAML_LEN(yaml), config, &top_schema,
+			(cyaml_data_t **) &data_tgt, NULL);
+	if (err != CYAML_OK) {
+		return ttest_fail(&tc, cyaml_strerror(err));
+	}
+
+	if (data_tgt->test != test) {
+		return ttest_fail(&tc, "Incorrect value");
+	}
+
+	return ttest_pass(&tc);
+}
+
+/**
  * Run the YAML loading unit tests.
  *
  * \param[in]  rc         The ttest report context.
@@ -10657,6 +11035,16 @@ bool load_tests(
 	pass &= test_load_mapping_field_default_float_ptr_zero(rc, &config);
 	pass &= test_load_mapping_field_default_double_ptr_zero(rc, &config);
 	pass &= test_load_mapping_field_default_bitfield_ptr_zero(rc, &config);
+
+	ttest_heading(rc, "Load tests: Integer range constraints");
+
+	pass &= test_load_mapping_field_range_int_1(rc, &config);
+	pass &= test_load_mapping_field_range_int_2(rc, &config);
+	pass &= test_load_mapping_field_range_int_3(rc, &config);
+	pass &= test_load_mapping_field_range_int_4(rc, &config);
+	pass &= test_load_mapping_field_range_uint_1(rc, &config);
+	pass &= test_load_mapping_field_range_uint_2(rc, &config);
+	pass &= test_load_mapping_field_range_uint_3(rc, &config);
 
 	return pass;
 }


### PR DESCRIPTION
If both the `min` and the `max` are zero, then the range check is ignored.

This means it's possible to leave them unset in a struct initialiser if you don't require the feature.

Closes #138.