### PR TITLE
Revert "Data: Switch to using C11 style static assert."

### DIFF
--- a/src/data.h
+++ b/src/data.h
@@ -58,9 +58,8 @@ static inline void cyaml_data_write_pointer(
 {
 	/* Refuse to build on platforms where sizeof pointer would
 	 * lead to \ref CYAML_ERR_INVALID_DATA_SIZE. */
-	static_assert(sizeof(char *) >  0, "Incompatible pointer size.");
-	static_assert(sizeof(char *) <= sizeof(uint64_t),
-			"Incompatible pointer size.");
+	cyaml_static_assert(sizeof(char *) >  0);
+	cyaml_static_assert(sizeof(char *) <= sizeof(uint64_t));
 
 	CYAML_UNUSED(cyaml_data_write((uint64_t)ptr, sizeof(ptr), data_target));
 
@@ -116,9 +115,8 @@ static inline uint8_t * cyaml_data_read_pointer(
 
 	/* Refuse to build on platforms where sizeof pointer would
 	 * lead to \ref CYAML_ERR_INVALID_DATA_SIZE. */
-	static_assert(sizeof(char *) >  0, "Incompatible pointer size.");
-	static_assert(sizeof(char *) <= sizeof(uint64_t),
-			"Incompatible pointer size.");
+	cyaml_static_assert(sizeof(char *) >  0);
+	cyaml_static_assert(sizeof(char *) <= sizeof(uint64_t));
 
 	return (void *)cyaml_data_read(sizeof(char *), data, &err);
 }

--- a/src/util.h
+++ b/src/util.h
@@ -15,6 +15,14 @@
 #include "cyaml/cyaml.h"
 #include "utf8.h"
 
+/** Compile time assertion macro. */
+#define cyaml_static_assert(e) \
+{ \
+	enum { \
+		cyaml_static_assert_check = 1 / (!!(e)) \
+	}; \
+}
+
 /** Macro to squash unused variable compiler warnings. */
 #define CYAML_UNUSED(_x) ((void)(_x))
 


### PR DESCRIPTION
This reverts commit a05e7db38073e5d1970e7797aafb46cfda668709.

Unfortunatly some versions of some platforms' C library headers don't provide the C11 static_assert macro wrapper for _Static_assert.

Rather than hacking around it, this reverts to using a C89-compatible static assertion macro.

Fixes https://github.com/tlsa/libcyaml/issues/230